### PR TITLE
Add new Gmail API Service Account Source type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,3 +304,4 @@ demo/
 
 # Secrets
 development/creds.env
+development/gmail_service_account_credentials.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - #23 - Make notifications more agnostic to multiple source types and improve `RawNotification` model
+- #26 - Add Gmail API Service Account Source type to Notification Sources
 
 ## v0.1.3 - 2021-06-10
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ Notification Sources are defined in two steps:
 
 #### 2.1 Define Notification Sources in `configuration.py`
 
-In the `PLUGINS_CONFIG`, under the `nautobot_circuit_maintenance` key, we should define the Notification Sources that will be able later in the UI.
+In the `PLUGINS_CONFIG`, under the `nautobot_circuit_maintenance` key, we should define the Notification Sources that will be able later in the UI, where you will be able to **validate** if the authentication credentials provided are working fine or not.
 
 There are two mandatory attributes (other keys are dependent on the integration type, and will be documented below):
 
 - `name`: Name to identify the Source and will be available in the UI.
 - `url`: URL to reach the Notification Source (i.e. `imap://imap.gmail.com:993`)
 
-> Currently, only IMAP email box integration is supported as URL scheme,
+> Currently, only IMAP and HTTPS (accounts.google.com) integrations are supported as URL scheme
 
 ##### IMAP
 
@@ -83,6 +83,35 @@ PLUGINS_CONFIG = {
                 "name": "my custom name",
                 "account": os.environ.get("CM_NS_1_ACCOUNT", ""),
                 "secret": os.environ.get("CM_NS_1_SECRET", ""),
+                "url": os.environ.get("CM_NS_1_URL", ""),
+            }
+        ]
+    }
+}
+```
+
+##### Gmail API Service Account
+
+There are 2 extra attributes:
+
+- `account`: Identifier (i.e. email address) to use to impersonate as service account.
+- `credentials_file`: JSON file containing all the necessary data to identify the Service Account.
+
+Enabling Gmail API access and create a [Service Account](https://support.google.com/a/answer/7378726?hl=en)involves multiple steps that could be summarised as:
+
+1. Create a **New Project** in [Google Cloud Console](https://console.cloud.google.com/).
+2. Under **APIs and Services**, enable **Gmail API** for the selected project.
+3. Still under **APIs and Services**, in **Credentials**, create a new **Service Account** and save the credentials file generated.
+4. With Admin rights, in the email account that this Service Account will impersonate, enable Google Workspace Domain-wide Delegation.
+
+```py
+PLUGINS_CONFIG = {
+    "nautobot_circuit_maintenance": {
+        "notification_sources": [
+            {
+                "name": "my custom name",
+                "account": os.environ.get("CM_NS_1_ACCOUNT", ""),
+                "credentials_file": os.environ.get("CM_NS_1_CREDENTIALS_FILE", ""),
                 "url": os.environ.get("CM_NS_1_URL", ""),
             }
         ]

--- a/README.md
+++ b/README.md
@@ -97,12 +97,14 @@ There are 2 extra attributes:
 - `account`: Identifier (i.e. email address) to use to impersonate as service account.
 - `credentials_file`: JSON file containing all the necessary data to identify the Service Account.
 
-Enabling Gmail API access and create a [Service Account](https://support.google.com/a/answer/7378726?hl=en)involves multiple steps that could be summarised as:
+Enabling Gmail API access and create a [Service Account](https://support.google.com/a/answer/7378726?hl=en) involves multiple steps that could be summarized as:
 
 1. Create a **New Project** in [Google Cloud Console](https://console.cloud.google.com/).
 2. Under **APIs and Services**, enable **Gmail API** for the selected project.
 3. Still under **APIs and Services**, in **Credentials**, create a new **Service Account** and save the credentials file generated.
-4. With Admin rights, in the email account that this Service Account will impersonate, enable Google Workspace Domain-wide Delegation.
+4. With Admin rights, edit the newly created Service Account and expand the **Show Domain-Wide Delegation** section. Enable Google Workspace Domain-wide Delegation and save the changes. Copy the Client ID shown.
+5. With Super Admin rights, open the [Google Workspace admin console](https://admin.google.com). Navigate to **Security**, **API controls**, and select the **Manage Domain Wide Delegation** at the bottom of the page.
+6. Add a new API client and paste in the Client ID copied earlier. In the **OAuth scopes** field add the scopes `https://www.googleapis.com/auth/gmail.readonly` and `https://mail.google.com/`. Save the new client configuration by clicking _Authorize_.
 
 ```py
 PLUGINS_CONFIG = {

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There are 2 extra attributes:
 - `account`: Identifier (i.e. email address) to use to impersonate as service account.
 - `credentials_file`: JSON file containing all the necessary data to identify the Service Account.
 
-Enabling Gmail API access and create a [Service Account](https://support.google.com/a/answer/7378726?hl=en) involves multiple steps that could be summarized as:
+Enabling Gmail API access and creating a [Service Account](https://support.google.com/a/answer/7378726?hl=en) involves multiple steps that could be summarized as:
 
 1. Create a **New Project** in [Google Cloud Console](https://console.cloud.google.com/).
 2. Under **APIs and Services**, enable **Gmail API** for the selected project.

--- a/development/creds.example.env
+++ b/development/creds.example.env
@@ -12,3 +12,6 @@ NAUTOBOT_SUPERUSER_PASSWORD=admin
 CM_NS_1_ACCOUNT=me@example.com
 CM_NS_1_SECRET=supersecret
 CM_NS_1_URL=imap://imap.gmail.com
+CM_NS_2_ACCOUNT=me@example.com
+CM_NS_2_URL=https://accounts.google.com/o/oauth2/auth
+CM_NS_2_CREDENTIALS_FILE=file_path

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -307,7 +307,13 @@ PLUGINS_CONFIG = {
                 "account": os.environ.get("CM_NS_1_ACCOUNT", ""),
                 "secret": os.environ.get("CM_NS_1_SECRET", ""),
                 "url": os.environ.get("CM_NS_1_URL", ""),
-            }
+            },
+            {
+                "name": "my gmail api source",
+                "url": os.environ.get("CM_NS_2_URL", ""),
+                "account": os.environ.get("CM_NS_2_ACCOUNT", ""),
+                "credentials_file": os.environ.get("CM_NS_2_CREDENTIALS_FILE", ""),
+            },
         ]
     }
 }

--- a/nautobot_circuit_maintenance/fixtures/source_gmail_api.yaml
+++ b/nautobot_circuit_maintenance/fixtures/source_gmail_api.yaml
@@ -14,21 +14,6 @@
     noc_contact: ""
     admin_contact: ""
     comments: ""
-- model: circuits.provider
-  pk: 6de61a64-f873-482a-9e33-97000b7f7515
-  fields:
-    created: 2021-04-30
-    last_updated: 2021-04-30 07:43:14.510402+00:00
-    _custom_field_data:
-      emails_circuit_maintenances: sender2@example.com
-    name: packetfabric
-    slug: packetfabric
-    asn: null
-    account: ""
-    portal_url: ""
-    noc_contact: ""
-    admin_contact: ""
-    comments: ""
 - model: circuits.circuittype
   pk: d1c2ed9d-9376-485b-b058-d26c29b5f22f
   fields:
@@ -74,17 +59,7 @@
     created: 2021-05-06
     last_updated: 2021-05-06 05:19:11.314056+00:00
     _custom_field_data: {}
-    name: "source imap"
-    slug: "source-imap"
-    providers:
-      - 0ec89992-0de0-483f-8f53-bdcd179eaecd
-- model: nautobot_circuit_maintenance.notificationsource
-  pk: 5fb2d3e4-4693-472c-8116-b4d7904eba66
-  fields:
-    created: 2021-06-16
-    last_updated: 2021-06-16 09:13:59.564410+00:00
-    _custom_field_data: {}
     name: "source gmail api"
     slug: "source-gmail-api"
     providers:
-      - 6de61a64-f873-482a-9e33-97000b7f7515
+      - 0ec89992-0de0-483f-8f53-bdcd179eaecd

--- a/nautobot_circuit_maintenance/fixtures/source_imap.yaml
+++ b/nautobot_circuit_maintenance/fixtures/source_imap.yaml
@@ -14,21 +14,6 @@
     noc_contact: ""
     admin_contact: ""
     comments: ""
-- model: circuits.provider
-  pk: 6de61a64-f873-482a-9e33-97000b7f7515
-  fields:
-    created: 2021-04-30
-    last_updated: 2021-04-30 07:43:14.510402+00:00
-    _custom_field_data:
-      emails_circuit_maintenances: sender2@example.com
-    name: packetfabric
-    slug: packetfabric
-    asn: null
-    account: ""
-    portal_url: ""
-    noc_contact: ""
-    admin_contact: ""
-    comments: ""
 - model: circuits.circuittype
   pk: d1c2ed9d-9376-485b-b058-d26c29b5f22f
   fields:
@@ -78,13 +63,3 @@
     slug: "source-imap"
     providers:
       - 0ec89992-0de0-483f-8f53-bdcd179eaecd
-- model: nautobot_circuit_maintenance.notificationsource
-  pk: 5fb2d3e4-4693-472c-8116-b4d7904eba66
-  fields:
-    created: 2021-06-16
-    last_updated: 2021-06-16 09:13:59.564410+00:00
-    _custom_field_data: {}
-    name: "source gmail api"
-    slug: "source-gmail-api"
-    providers:
-      - 6de61a64-f873-482a-9e33-97000b7f7515

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -136,6 +136,10 @@ class EmailSource(Source):  # pylint: disable=abstract-method
     account: str
     emails_to_fetch = []
 
+    def get_account_id(self) -> str:
+        """Method to get an identifier of the related account."""
+        return self.account
+
     def validate_providers(self, logger: Job, notification_source: NotificationSource, since_txt: str) -> bool:
         """Method to validate that the NotificationSource has attached Providers.
 
@@ -245,10 +249,6 @@ class IMAP(EmailSource):
         """Pydantic BaseModel config."""
 
         arbitrary_types_allowed = True
-
-    def get_account_id(self) -> str:
-        """Method to get an identifier of the related account."""
-        return self.user
 
     def open_session(self):
         """Open session to IMAP server."""

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -1,11 +1,17 @@
 """Notification Source classes."""
+import base64
 import re
 import datetime
 import email
-import imaplib
 from urllib.parse import urlparse
 from email.utils import mktime_tz, parsedate_tz
-from typing import Iterable, Optional, TypeVar, Type, Tuple
+from typing import Iterable, Optional, TypeVar, Type, Tuple, Dict
+
+import imaplib
+
+from googleapiclient.discovery import build, Resource
+from google.oauth2 import service_account
+from google.auth.transport.requests import Request
 
 from django.conf import settings
 
@@ -56,6 +62,10 @@ class Source(BaseModel):
         """
         raise NotImplementedError
 
+    def _authentication_logic(self):
+        """Inner method to run the custom class validation logic."""
+        raise NotImplementedError
+
     def test_authentication(self) -> Tuple[bool, str]:
         """Method to validate the authentication of the Source.
 
@@ -64,7 +74,17 @@ class Source(BaseModel):
                 bool: True if authentication was successful, False otherwise
                 str: Message from authentication execution
         """
-        raise NotImplementedError
+        try:
+            self._authentication_logic()
+            is_authenticated = True
+            message = "Test OK"
+        except Exception as exc:
+            is_authenticated = False
+            if isinstance(exc.args[0], bytes):
+                message = str(exc.args[0].decode())
+            else:
+                message = str(exc)
+        return is_authenticated, message
 
     @classmethod
     def init(cls: Type[T], name: str) -> Type[T]:
@@ -88,164 +108,27 @@ class Source(BaseModel):
             return IMAP(
                 name=name,
                 url=url,
-                user=config.get("account"),
+                account=config.get("account"),
                 password=config.get("secret"),
                 imap_server=url_components.netloc.split(":")[0],
                 imap_port=url_components.port or 993,
+            )
+        if scheme == "https" and url_components.netloc.split(":")[0] == "accounts.google.com":
+            return GmailAPIServiceAccount(
+                name=name,
+                url=url,
+                account=config.get("account"),
+                credentials_file=config.get("credentials_file"),
             )
 
         raise ValueError(f"Scheme {scheme} not supported as Notification Source (only IMAP).")
 
 
-class IMAP(Source):
-    """IMAP class, extending Source class."""
+class EmailSource(Source):  # pylint: disable=abstract-method
+    """Abstract class that shares some methods and attributes accross email based sources."""
 
-    user: str
-    password: str
-    imap_server: str
-    imap_port: int = 993
-
-    session: Optional[imaplib.IMAP4_SSL] = None
+    account: str
     emails_to_fetch = []
-
-    class Config:
-        """Pydantic BaseModel config."""
-
-        arbitrary_types_allowed = True
-
-    def open_session(self):
-        """Open session to IMAP server."""
-        if not self.session:
-            self.session = imaplib.IMAP4_SSL(self.imap_server, self.imap_port)
-            self.session.login(self.user, self.password)
-
-    def close_session(self):
-        """Close session to IMAP server."""
-        if self.session:
-            if self.session.state == "SELECTED":
-                self.session.close()
-            if self.session.state == "AUTH":
-                self.session.logout()
-
-    def test_authentication(self) -> Tuple[bool, str]:
-        """Method to validate the authentication of the Source.
-
-        Returns:
-            Tuple:
-                bool: True if authentication was successful, False otherwise
-                str: Message from authentication execution
-        """
-        try:
-            self.open_session()
-            self.close_session()
-            is_authenticated = True
-            message = "Test OK"
-        except Exception as exc:
-            is_authenticated = False
-            if isinstance(exc.args[0], bytes):
-                message = str(exc.args[0].decode())
-            else:
-                message = str(exc)
-        return is_authenticated, message
-
-    # pylint: disable=inconsistent-return-statements
-    def fetch_email(self, logger: Job, msg_id: bytes, since: Optional[int]) -> Optional[MaintenanceNotification]:
-        """Fetch an specific email ID."""
-        _, data = self.session.fetch(msg_id, "(RFC822)")
-        raw_email = data[0][1]
-        raw_email_string = raw_email.decode("utf-8")
-        email_message = email.message_from_string(raw_email_string)
-
-        if since:
-            if mktime_tz(parsedate_tz(email_message["Date"])) < since:
-                logger.log_info(message=f"'{email_message['Subject']}' email is old, so not taking into account.")
-                return
-
-        try:
-            email_source = re.search(r"\<([A-Za-z0-9_@.]+)\>", email_message["From"]).group(1)
-        except AttributeError:
-            try:
-                email_source = re.search(r"([A-Za-z0-9_@.]+)", email_message["From"]).group(1)
-            except AttributeError:
-                logger.log_failure(
-                    email_message, f"Not possible to determine the email sender: {email_message['From']}"
-                )
-                return
-
-        for provider in Provider.objects.all():
-            if "emails_circuit_maintenances" in provider.custom_field_data:
-                if email_source in provider.custom_field_data["emails_circuit_maintenances"].split(","):
-                    provider_type = provider.slug
-                    break
-        else:
-            logger.log_warning(
-                message=f"Sender email {email_source} is not registered for any circuit provider.",
-            )
-            return
-
-        try:
-            provider_data_type = get_provider_data_type(provider_type)
-        except NonexistentParserError:
-            logger.log_warning(
-                message=f"Unexpected provider {provider_type} received from {email_message['From']}, so not getting the notification",
-            )
-            return
-
-        for part in email_message.walk():
-            if part.get_content_type() == provider_data_type:
-                raw_payload = part.get_payload()
-                break
-        else:
-            logger.log_warning(
-                message=f"Payload type {provider_data_type} not found in email payload.",
-            )
-            return
-
-        return MaintenanceNotification(
-            source=self.name,
-            sender=email_message["From"],
-            subject=email_message["Subject"],
-            raw=raw_payload,
-            provider_type=provider_type,
-        )
-
-    def receive_notifications(self, logger: Job, since: int = None) -> Iterable[MaintenanceNotification]:
-        """Retrieve emails since an specific time, if provided."""
-        self.open_session()
-
-        # Define searching criteria
-        self.session.select("Inbox")
-
-        # TODO: find the right way to search messages from several senders
-        # Maybe extend filtering options, for instance, to discard some type of notifications
-        msg_ids = []
-        since_date = ""
-        if since:
-            # IMAP search time criteria does not work for hours/minutes/seconds
-            since_txt = datetime.datetime.fromtimestamp(since).strftime("%d-%b-%Y")
-            since_date = f'SINCE "{since_txt}"'
-
-        if self.emails_to_fetch:
-            for sender in self.emails_to_fetch:
-                search_items = (f'FROM "{sender}"', since_date)
-                search_text = " ".join(search_items).strip()
-                search_criteria = f"({search_text})"
-                messages = self.session.search(None, search_criteria)[1][0]
-                msg_ids.extend(messages.split())
-        else:
-            search_criteria = f"({since_date})"
-            messages = self.session.search(None, search_criteria)[1][0]
-            msg_ids.extend = messages.split()
-
-        received_notifications = []
-
-        for msg_id in msg_ids:
-            raw_notification = self.fetch_email(logger, msg_id, since)
-            if raw_notification:
-                received_notifications.append(raw_notification)
-
-        self.close_session()
-        return received_notifications
 
     def validate_providers(self, logger: Job, notification_source: NotificationSource, since_txt: str) -> bool:
         """Method to validate that the NotificationSource has attached Providers.
@@ -262,7 +145,7 @@ class IMAP(Source):
         providers_without_email = []
         if not notification_source.providers.all():
             logger.log_warning(
-                message="Skipping this email account no providers were defined.",
+                message=f"Skipping source '{notification_source.name}' because no providers were defined.",
             )
             return False
 
@@ -299,6 +182,313 @@ class IMAP(Source):
         )
 
         return True
+
+    @staticmethod
+    def extract_email_source(email_source: str) -> str:
+        """Method to get the sender email address."""
+        try:
+            email_source = re.search(r"\<([A-Za-z0-9_@.]+)\>", email_source).group(1)
+        except AttributeError:
+            try:
+                email_source = re.search(r"([A-Za-z0-9_@.]+)", email_source).group(1)
+            except AttributeError:
+                return ""
+        return email_source
+
+    @staticmethod
+    def extract_provider_data_type(email_source: str) -> Tuple[str, str, str]:
+        """Method to extract the provider data type based on the referenced email for the provider."""
+        for provider in Provider.objects.all():
+            if "emails_circuit_maintenances" in provider.custom_field_data:
+                if email_source in provider.custom_field_data["emails_circuit_maintenances"].split(","):
+                    provider_type = provider.slug
+                    break
+        else:
+            return "", "", f"Sender email {email_source} is not registered for any circuit provider."
+
+        try:
+            provider_data_type = get_provider_data_type(provider_type)
+        except NonexistentParserError:
+            return (
+                "",
+                "",
+                f"Unexpected provider {provider_type} received from {email_source}, so not getting the notification",
+            )
+
+        return provider_data_type, provider_type, ""
+
+
+class IMAP(EmailSource):
+    """IMAP class, extending Source class."""
+
+    password: str
+    imap_server: str
+    imap_port: int = 993
+
+    session: Optional[imaplib.IMAP4_SSL] = None
+
+    class Config:
+        """Pydantic BaseModel config."""
+
+        arbitrary_types_allowed = True
+
+    def open_session(self):
+        """Open session to IMAP server."""
+        if not self.session:
+            self.session = imaplib.IMAP4_SSL(self.imap_server, self.imap_port)
+            self.session.login(self.account, self.password)
+
+    def close_session(self):
+        """Close session to IMAP server."""
+        if self.session:
+            if self.session.state == "SELECTED":
+                self.session.close()
+            if self.session.state == "AUTH":
+                self.session.logout()
+
+    def _authentication_logic(self):
+        """Inner method to run the custom class validation logic."""
+        self.open_session()
+        self.close_session()
+
+    # pylint: disable=inconsistent-return-statements
+    def fetch_email(self, logger: Job, msg_id: bytes, since: Optional[int]) -> Optional[MaintenanceNotification]:
+        """Fetch an specific email ID."""
+        _, data = self.session.fetch(msg_id, "(RFC822)")
+        raw_email = data[0][1]
+        raw_email_string = raw_email.decode("utf-8")
+        email_message = email.message_from_string(raw_email_string)
+
+        if since:
+            if mktime_tz(parsedate_tz(email_message["Date"])) < since:
+                logger.log_info(message=f"'{email_message['Subject']}' email is old, so not taking into account.")
+                return
+
+        email_source = self.extract_email_source(email_message["From"])
+        if not email_source:
+            logger.log_failure(message=f"Not possible to determine the email sender: {email_message['From']}")
+            return None
+
+        provider_data_type, provider_type, error_message = self.extract_provider_data_type(email_source)
+        if not provider_data_type:
+            logger.log_warning(message=error_message)
+
+        for part in email_message.walk():
+            if part.get_content_type() == provider_data_type:
+                raw_payload = part.get_payload()
+                break
+        else:
+            logger.log_warning(
+                message=f"Payload type {provider_data_type} not found in email payload.",
+            )
+            return
+
+        return MaintenanceNotification(
+            source=self.name,
+            sender=email_message["From"],
+            subject=email_message["Subject"],
+            raw=raw_payload,
+            provider_type=provider_type,
+        )
+
+    def receive_notifications(self, logger: Job, since: int = None) -> Iterable[MaintenanceNotification]:
+        """Retrieve emails since an specific time, if provided."""
+        self.open_session()
+
+        # Define searching criteria
+        self.session.select("Inbox")
+
+        # TODO: find the right way to search messages from several senders
+        # Maybe extend filtering options, for instance, to discard some type of notifications
+        msg_ids = []
+        since_date = ""
+        if since:
+            since_txt = datetime.datetime.fromtimestamp(since).strftime("%d-%b-%Y")
+            since_date = f'SINCE "{since_txt}"'
+
+        if self.emails_to_fetch:
+            for sender in self.emails_to_fetch:
+                search_items = (f'FROM "{sender}"', since_date)
+                search_text = " ".join(search_items).strip()
+                search_criteria = f"({search_text})"
+                messages = self.session.search(None, search_criteria)[1][0]
+                msg_ids.extend(messages.split())
+        else:
+            search_criteria = f"({since_date})"
+            messages = self.session.search(None, search_criteria)[1][0]
+            msg_ids.extend = messages.split()
+
+        received_notifications = []
+        for msg_id in msg_ids:
+            raw_notification = self.fetch_email(logger, msg_id, since)
+            if raw_notification:
+                received_notifications.append(raw_notification)
+
+        self.close_session()
+        return received_notifications
+
+
+class GmailAPIServiceAccount(EmailSource):
+    """GmailAPIServiceAccount class.
+
+    See: https://developers.google.com/gmail/api/reference/rest/v1/users.messages
+    """
+
+    credentials_file: str
+    account: str
+    service: Optional[Resource] = None
+    credentials: Optional[service_account.Credentials] = None
+
+    SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
+
+    class Config:
+        """Pydantic BaseModel config."""
+
+        arbitrary_types_allowed = True
+
+    def load_credentials(self):
+        """Load Gmail API Service Account credentials."""
+        if not self.credentials:
+            self.credentials = service_account.Credentials.from_service_account_file(self.credentials_file)
+            self.credentials = self.credentials.with_scopes(self.SCOPES)
+            self.credentials = self.credentials.with_subject(self.account)
+            self.credentials.refresh(Request())
+
+    def build_service(self):
+        """Build API service."""
+        self.service = build("gmail", "v1", credentials=self.credentials)
+
+    def close_service(self):
+        """Close API Service."""
+        if self.service:
+            self.service.close()
+
+    def _authentication_logic(self):
+        """Inner method to run the custom class validation logic."""
+        self.load_credentials()
+
+    def extract_raw_payload(self, body: Dict, msg_id: bytes) -> bytes:
+        """Extracts the raw_payload from body or attachement."""
+        if "attachmentId" in body:
+            attachment = (
+                self.service.users()  # pylint: disable=no-member
+                .messages()
+                .attachments()
+                .get(userId=self.account, messageId=msg_id, id=body["attachmentId"])
+                .execute()
+            )
+            return base64.b64decode(attachment["data"])
+        if "data" in body:
+            return base64.urlsafe_b64decode(body["data"])
+
+        return b""
+
+    # pylint: disable=inconsistent-return-statements,too-many-locals,too-many-branches
+    def fetch_email(self, logger: Job, msg_id: bytes, since: Optional[int]) -> Optional[MaintenanceNotification]:
+        """Fetch an specific email ID.
+
+        See data format:  https://developers.google.com/gmail/api/reference/rest/v1/users.messages#Message
+        """
+        received_email = (
+            self.service.users().messages().get(userId=self.account, id=msg_id).execute()  # pylint: disable=no-member
+        )
+        email_subject = ""
+        email_source = ""
+
+        for header in received_email["payload"]["headers"]:
+            if header.get("name") == "Subject":
+                email_subject = header["value"]
+            elif header.get("name") == "From":
+                email_source = header["value"]
+
+        if not email_subject or not email_source:
+            logger.log_warning(
+                received_email, message="Received email doesn't contain either Suject or From, so skipping it."
+            )
+            return
+
+        if since:
+            if received_email["internalDate"] < since:
+                logger.log_info(message=f"'{email_subject}' email is old, so not taking into account.")
+                return
+
+        email_source_before = email_source
+        email_source = self.extract_email_source(email_source)
+        if not email_source:
+            logger.log_failure(message=f"Not possible to determine the email sender: {email_source_before}")
+            return
+
+        provider_data_type, provider_type, error_message = self.extract_provider_data_type(email_source)
+        if not provider_data_type:
+            logger.log_warning(message=error_message)
+
+        raw_payload = ""
+        for part in received_email["payload"]["parts"]:
+            content_type = ""
+            for header in part["headers"]:
+                if header.get("name") == "Content-Type":
+                    content_type = header.get("value")
+            if provider_data_type in content_type:
+                raw_payload = self.extract_raw_payload(part["body"], msg_id)
+            elif "multipart" in content_type:
+                for part_inner in part["parts"]:
+                    for header_inner in part_inner["headers"]:
+                        if header_inner.get("name") == "Content-Type" and provider_data_type in header_inner.get(
+                            "value"
+                        ):
+                            raw_payload = self.extract_raw_payload(part_inner["body"], msg_id)
+                        if raw_payload:
+                            break
+                    if raw_payload:
+                        break
+            if raw_payload:
+                break
+
+        if not raw_payload:
+            logger.log_warning(
+                message=f"Payload type {provider_data_type} not found in email payload.",
+            )
+            return
+
+        return MaintenanceNotification(
+            source=self.name,
+            sender=email_source,
+            subject=email_subject,
+            raw=raw_payload,
+            provider_type=provider_type,
+        )
+
+    def receive_notifications(self, logger: Job, since: int = None) -> Iterable[MaintenanceNotification]:
+        """Retrieve emails since an specific time, if provided."""
+        self.load_credentials()
+        self.build_service()
+
+        search_criteria = ""
+        if since:
+            since_txt = datetime.datetime.fromtimestamp(since).strftime("%Y/%b/%d")
+            search_criteria = f'after:"{since_txt}"'
+
+        if self.emails_to_fetch:
+            emails_with_from = [f"from:{email}" for email in self.emails_to_fetch]
+            search_criteria += f'({" OR ".join(emails_with_from)})'
+
+        # TODO: For now not covering pagination as a way to limit the number of messages
+        res = (
+            self.service.users()  # pylint: disable=no-member
+            .messages()
+            .list(userId=self.account, q=search_criteria)
+            .execute()
+        )
+        msg_ids = [msg["id"] for msg in res.get("messages", [])]
+
+        received_notifications = []
+        for msg_id in msg_ids:
+            raw_notification = self.fetch_email(logger, msg_id, since)
+            if raw_notification:
+                received_notifications.append(raw_notification)
+
+        self.close_service()
+        return received_notifications
 
 
 def get_notifications(

--- a/nautobot_circuit_maintenance/tests/test_sources.py
+++ b/nautobot_circuit_maintenance/tests/test_sources.py
@@ -8,44 +8,43 @@ from nautobot.circuits.models import Provider
 
 from nautobot_circuit_maintenance.models import NotificationSource
 
-from nautobot_circuit_maintenance.handle_notifications.sources import Source, IMAP, get_notifications
+from nautobot_circuit_maintenance.handle_notifications.sources import (
+    Source,
+    IMAP,
+    get_notifications,
+    GmailAPIServiceAccount,
+    EmailSource,
+)
 from .test_handler import get_base_notification_data, generate_raw_notification
 
 
-SOURCE_1 = {
-    "name": "example",
+SOURCE_IMAP = {
+    "name": "source imap",
     "account": "me@example.com",
     "secret": "supersecret",
     "url": "imap://example.com",
 }
 
+SOURCE_GMAIL_API = {
+    "name": "source gmail api",
+    "account": "me@example.com",
+    "url": "https://accounts.google.com/o/oauth2/auth",
+    "credentials_file": "path_to_credentials",
+}
 
-class TestSources(TestCase):
-    """Test case for all the related methods in Email Helper."""
+
+class TestSource(TestCase):
+    """Test case for IMAP Source."""
 
     fixtures = ["handle_notifications_job.yaml"]
 
-    logger = Mock()
-    logger.log_info = Mock()
-    logger.log_warning = Mock()
-
     def setUp(self):
         """Prepare data for tests."""
-        settings.PLUGINS_CONFIG = {"nautobot_circuit_maintenance": {"notification_sources": [SOURCE_1.copy()]}}
+        settings.PLUGINS_CONFIG = {
+            "nautobot_circuit_maintenance": {"notification_sources": [SOURCE_IMAP.copy(), SOURCE_GMAIL_API.copy()]}
+        }
         # Deleting other NotificationSource to define a reliable state.
-        NotificationSource.objects.exclude(name=SOURCE_1["name"]).delete()
-        self.source = NotificationSource.objects.first()
-
-    def test_source_factory(self):
-        """Validate Factory pattern for Source class."""
-        source_instance = Source.init(name=SOURCE_1["name"])
-        self.assertIsInstance(source_instance, IMAP)
-        self.assertEqual(source_instance.name, SOURCE_1["name"])
-        self.assertEqual(source_instance.url, SOURCE_1["url"])
-        self.assertEqual(source_instance.account, SOURCE_1["account"])
-        self.assertEqual(source_instance.password, SOURCE_1["secret"])
-        self.assertEqual(source_instance.imap_server, "example.com")
-        self.assertEqual(source_instance.imap_port, 993)
+        NotificationSource.objects.exclude(name__in=[SOURCE_IMAP["name"], SOURCE_GMAIL_API["name"]]).delete()
 
     def test_source_factory_nonexistent_name(self):
         """Validate Factory pattern for non existent name."""
@@ -56,41 +55,133 @@ class TestSources(TestCase):
     def test_source_factory_nonexistent_url(self):
         """Validate Factory pattern for non existent url."""
         del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["url"]
-        with self.assertRaisesMessage(ValueError, f"URL for {SOURCE_1['name']} not found in PLUGINS_CONFIG"):
-            Source.init(name=SOURCE_1["name"])
+        with self.assertRaisesMessage(ValueError, f"URL for {SOURCE_IMAP['name']} not found in PLUGINS_CONFIG"):
+            Source.init(name=SOURCE_IMAP["name"])
 
     def test_source_factory_url_scheme_not_supported(self):
         """Validate Factory pattern for non existent url scheme."""
         settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["url"] = "ftp://example.com"
-        with self.assertRaisesMessage(ValueError, "Scheme ftp not supported as Notification Source (only IMAP)."):
-            Source.init(name=SOURCE_1["name"])
+        with self.assertRaisesMessage(
+            ValueError,
+            "Scheme ftp not supported as Notification Source (only IMAP or HTTPS to accounts.google.com).",
+        ):
+            Source.init(name=SOURCE_IMAP["name"])
 
     def test_source_factory_url_malformed(self):
         """Validate Factory pattern for malformed url."""
         settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["url"] = "wrong url"
-        with self.assertRaisesMessage(ValueError, "Scheme  not supported as Notification Source (only IMAP)"):
-            Source.init(name=SOURCE_1["name"])
+        with self.assertRaisesMessage(
+            ValueError,
+            "Scheme  not supported as Notification Source (only IMAP or HTTPS to accounts.google.com).",
+        ):
+            Source.init(name=SOURCE_IMAP["name"])
+
+
+class TestEmailSource(TestCase):
+    """Test case for EmailSource."""
+
+    @parameterized.expand(
+        [
+            ["user@example.com", "user@example.com"],
+            ["<user@example.com>", "user@example.com"],
+            ["user <user@example.com>", "user@example.com"],
+        ]  # pylint: disable=too-many-arguments
+    )
+    def test_extract_email_source(self, email_source, email_source_output):
+        """Test for extract_email_source."""
+        self.assertEqual(EmailSource.extract_email_source(email_source), email_source_output)
+
+    def test_extract_provider_data_type_no_email(self):
+        """Test for extract_provider_data_type when Provider doens't have the email."""
+        Provider.objects.create(name="whatever", slug="whatever")
+        email_source = "user@example.com"
+        self.assertEqual(
+            EmailSource.extract_provider_data_type(email_source),
+            ("", "", f"Sender email {email_source} is not registered for any circuit provider."),
+        )
+
+    def test_extract_provider_data_type_no_provider_parser(self):
+        """Test for extract_provider_data_type when Provider doesn't have the email."""
+        provider_type = "whatever"
+        email_source = "user@example.com"
+        provider = Provider.objects.create(name=provider_type, slug=provider_type)
+        provider.cf["emails_circuit_maintenances"] = email_source
+        provider.save()
+
+        self.assertEqual(
+            EmailSource.extract_provider_data_type(email_source),
+            (
+                "",
+                "",
+                f"Unexpected provider {provider_type} received from {email_source}, so not getting the notification",
+            ),
+        )
+
+    def test_extract_provider_data_type_ok(self):
+        """Test for extract_provider_data_type."""
+        provider_type = "ntt"
+        email_source = "user@example.com"
+        provider = Provider.objects.create(name=provider_type, slug=provider_type)
+        provider.cf["emails_circuit_maintenances"] = email_source
+        provider.save()
+
+        self.assertEqual(
+            EmailSource.extract_provider_data_type(email_source),
+            (
+                "text/calendar",
+                "ntt",
+                "",
+            ),
+        )
+
+
+class TestIMAPSource(TestCase):
+    """Test case for IMAP Source."""
+
+    fixtures = ["source_imap.yaml"]
+
+    logger = Mock()
+    logger.log_info = Mock()
+    logger.log_warning = Mock()
+
+    def setUp(self):
+        """Prepare data for tests."""
+        settings.PLUGINS_CONFIG = {"nautobot_circuit_maintenance": {"notification_sources": [SOURCE_IMAP.copy()]}}
+        # Deleting other NotificationSource to define a reliable state.
+        NotificationSource.objects.exclude(name__in=[SOURCE_IMAP["name"]]).delete()
+        self.source = NotificationSource.objects.get(name=SOURCE_IMAP["name"])
+
+    def test_source_factory(self):
+        """Validate Factory pattern for Source class."""
+        source_instance = Source.init(name=SOURCE_IMAP["name"])
+        self.assertIsInstance(source_instance, IMAP)
+        self.assertEqual(source_instance.name, SOURCE_IMAP["name"])
+        self.assertEqual(source_instance.url, SOURCE_IMAP["url"])
+        self.assertEqual(source_instance.account, SOURCE_IMAP["account"])
+        self.assertEqual(source_instance.password, SOURCE_IMAP["secret"])
+        self.assertEqual(source_instance.imap_server, "example.com")
+        self.assertEqual(source_instance.imap_port, 993)
 
     def test_source_factory_imap_no_account(self):
         """Validate Factory pattern IMAP without account settings."""
         del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["account"]
         with self.assertRaises(ValidationError):
-            Source.init(name=SOURCE_1["name"])
+            Source.init(name=SOURCE_IMAP["name"])
 
     def test_source_factory_imap_no_secret(self):
         """Validate Factory pattern IMAP without secret settings."""
         del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["secret"]
         with self.assertRaises(ValidationError):
-            Source.init(name=SOURCE_1["name"])
+            Source.init(name=SOURCE_IMAP["name"])
 
     def test_get_notifications_without_providers(self):
         """Test get_notifications when there are no Providers defined."""
-        notification_source = NotificationSource.objects.all().first()
+        notification_source = NotificationSource.objects.get(name=SOURCE_IMAP["name"])
         notification_source.providers.set([])
 
         res = get_notifications(self.logger, NotificationSource.objects.all())
         self.assertEqual([], res)
-        source_name = SOURCE_1["name"]
+        source_name = SOURCE_IMAP["name"]
         self.logger.log_warning.assert_called_with(
             message=f"Skipping source '{source_name}' because no providers were defined."
         )
@@ -121,7 +212,7 @@ class TestSources(TestCase):
         get_notifications(self.logger, NotificationSource.objects.all())
 
         self.logger.log_warning.assert_called_with(
-            message=f"Notification Source {SOURCE_1['name']} is not matching class expectations: 1 validation error for IMAP\naccount\n  none is not an allowed value (type=type_error.none.not_allowed)"
+            message=f"Notification Source {SOURCE_IMAP['name']} is not matching class expectations: 1 validation error for IMAP\naccount\n  none is not an allowed value (type=type_error.none.not_allowed)"
         )
 
     @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.receive_notifications")
@@ -140,7 +231,6 @@ class TestSources(TestCase):
     @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.receive_notifications")
     def test_get_notifications_multiple(self, mock_receive_notifications):
         """Test get_notifications multiple."""
-
         notification_data = get_base_notification_data()
         notification = generate_raw_notification(notification_data, self.source.name)
 
@@ -154,20 +244,20 @@ class TestSources(TestCase):
     @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.close_session")
     @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.open_session")
     def test_imap_test_authentication_ok(self, mock_open, mock_close):  # pylint: disable=unused-argument
-        imap = IMAP(
+        source = IMAP(
             name="whatever", url="imap://localhost", account="account", password="pass", imap_server="localhost"
         )
-        res, message = imap.test_authentication()
+        res, message = source.test_authentication()
         self.assertEqual(res, True)
         self.assertEqual(message, "Test OK")
 
     @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.open_session")
     def test_imap_test_authentication_ko(self, mock_open):
         mock_open.side_effect = Exception("error message")
-        imap = IMAP(
+        source = IMAP(
             name="whatever", url="imap://localhost", account="account", password="pass", imap_server="localhost"
         )
-        res, message = imap.test_authentication()
+        res, message = source.test_authentication()
         self.assertEqual(res, False)
         self.assertEqual(message, "error message")
 
@@ -201,3 +291,162 @@ class TestSources(TestCase):
                 IMAP(**kwargs)
         else:
             IMAP(**kwargs)
+
+
+class TestGmailAPISource(TestCase):
+    """Test case for GmailAPI Source."""
+
+    fixtures = ["source_gmail_api.yaml"]
+
+    logger = Mock()
+    logger.log_info = Mock()
+    logger.log_warning = Mock()
+
+    def setUp(self):
+        """Prepare data for tests."""
+        settings.PLUGINS_CONFIG = {"nautobot_circuit_maintenance": {"notification_sources": [SOURCE_GMAIL_API.copy()]}}
+        # Deleting other NotificationSource and Provider to define a reliable state.
+        NotificationSource.objects.exclude(name__in=[SOURCE_GMAIL_API["name"]]).delete()
+        self.source = NotificationSource.objects.get(name=SOURCE_GMAIL_API["name"])
+
+    def test_source_factory(self):
+        """Validate Factory pattern for Source class."""
+        source_instance = Source.init(name=SOURCE_GMAIL_API["name"])
+        self.assertIsInstance(source_instance, GmailAPIServiceAccount)
+        self.assertEqual(source_instance.name, SOURCE_GMAIL_API["name"])
+        self.assertEqual(source_instance.url, SOURCE_GMAIL_API["url"])
+        self.assertEqual(source_instance.account, SOURCE_GMAIL_API["account"])
+        self.assertEqual(source_instance.credentials_file, SOURCE_GMAIL_API["credentials_file"])
+
+    def test_source_factory_imap_no_account(self):
+        """Validate Factory pattern Gmail API without account settings."""
+        del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["account"]
+        with self.assertRaises(ValidationError):
+            Source.init(name=SOURCE_GMAIL_API["name"])
+
+    def test_source_factory_imap_no_secret(self):
+        """Validate Factory pattern Gmail API without credentials_file."""
+        del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["credentials_file"]
+        with self.assertRaises(ValidationError):
+            Source.init(name=SOURCE_GMAIL_API["name"])
+
+    def test_get_notifications_without_providers(self):
+        """Test get_notifications when there are no Providers defined."""
+        notification_source = NotificationSource.objects.get(name=SOURCE_GMAIL_API["name"])
+        notification_source.providers.set([])
+
+        res = get_notifications(self.logger, NotificationSource.objects.all())
+        self.assertEqual([], res)
+        source_name = SOURCE_GMAIL_API["name"]
+        self.logger.log_warning.assert_called_with(
+            message=f"Skipping source '{source_name}' because no providers were defined."
+        )
+
+    @patch("nautobot_circuit_maintenance.handle_notifications.sources.GmailAPIServiceAccount.receive_notifications")
+    def test_get_notifications_without_notifications(self, mock_receive_notifications):
+        """Test get_notifications with provider without email in one of the provider and without notifications."""
+        mock_receive_notifications.return_value = []
+        original_provider = Provider.objects.all().first()
+        new_provider = Provider.objects.create(name="something", slug="something")
+        notification_source = NotificationSource.objects.all().first()
+        notification_source.providers.add(original_provider)
+        notification_source.providers.add(new_provider)
+
+        res = get_notifications(self.logger, NotificationSource.objects.all())
+        self.assertEqual([], res)
+
+        self.logger.log_warning.assert_called_with(
+            message=f"Skipping {new_provider.name} because these providers have no email configured."
+        )
+        self.logger.log_info.assert_called_with(
+            message=f"No notifications received for {original_provider}, {new_provider} since always from {notification_source.name}"
+        )
+
+    def test_get_notifications_no_account(self):
+        """Test get_notifications without account."""
+        del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["account"]
+        get_notifications(self.logger, NotificationSource.objects.all())
+
+        self.logger.log_warning.assert_called_with(
+            message=f"Notification Source {SOURCE_GMAIL_API['name']} is not matching class expectations: 1 validation error for GmailAPIServiceAccount\naccount\n  none is not an allowed value (type=type_error.none.not_allowed)"
+        )
+
+    @patch("nautobot_circuit_maintenance.handle_notifications.sources.GmailAPIServiceAccount.receive_notifications")
+    def test_get_notifications(self, mock_receive_notifications):
+        """Test get_notifications."""
+        notification_data = get_base_notification_data()
+        notification = generate_raw_notification(notification_data, self.source.name)
+
+        mock_receive_notifications.return_value = [notification]
+
+        res = get_notifications(self.logger, NotificationSource.objects.all())
+
+        self.assertEqual(1, len(res))
+        self.logger.log_warning.assert_not_called()
+
+    @patch("nautobot_circuit_maintenance.handle_notifications.sources.GmailAPIServiceAccount.receive_notifications")
+    def test_get_notifications_multiple(self, mock_receive_notifications):
+        """Test get_notifications multiple."""
+        notification_data = get_base_notification_data()
+        notification = generate_raw_notification(notification_data, self.source.name)
+
+        mock_receive_notifications.return_value = [notification, notification]
+
+        res = get_notifications(self.logger, NotificationSource.objects.all())
+
+        self.assertEqual(2, len(res))
+        self.logger.log_warning.assert_not_called()
+
+    @parameterized.expand(
+        [
+            ["name_1", "url1", "user_1", "credentials_file", False],
+            ["name_1", "url1", None, "credentials_file", True],
+            ["name_1", "url1", "user_1", None, True],
+        ]  # pylint: disable=too-many-arguments
+    )
+    def test_gmail_api_service_account_init(self, name, url, account, credentials_file, exception):
+        """Test Gmail API class init."""
+        kwargs = {}
+        if name:
+            kwargs["name"] = name
+        if url:
+            kwargs["url"] = url
+        if account:
+            kwargs["account"] = account
+        if credentials_file:
+            kwargs["credentials_file"] = credentials_file
+
+        if exception:
+            with self.assertRaises(ValidationError):
+                GmailAPIServiceAccount(**kwargs)
+        else:
+            GmailAPIServiceAccount(**kwargs)
+
+    @patch("nautobot_circuit_maintenance.handle_notifications.sources.GmailAPIServiceAccount.load_credentials")
+    def test_gmail_api_service_account_test_authentication_ok(
+        self, mock_credentials
+    ):  # pylint: disable=unused-argument
+        source = GmailAPIServiceAccount(
+            name="whatever",
+            url="https://accounts.google.com/o/oauth2/auth",
+            account="account",
+            credentials_file="path_to_file",
+        )
+        res, message = source.test_authentication()
+        self.assertEqual(res, True)
+        self.assertEqual(message, "Test OK")
+
+    @patch("nautobot_circuit_maintenance.handle_notifications.sources.GmailAPIServiceAccount.load_credentials")
+    def test_gmail_api_service_account_test_authentication_ko(
+        self, mock_credentials
+    ):  # pylint: disable=unused-argument
+        mock_credentials.side_effect = Exception("error message")
+        source = GmailAPIServiceAccount(
+            name="whatever",
+            url="https://accounts.google.com/o/oauth2/auth",
+            account="account",
+            credentials_file="path_to_file",
+        )
+        res, message = source.test_authentication()
+        self.assertEqual(res, False)
+        self.assertEqual(message, "error message")

--- a/poetry.lock
+++ b/poetry.lock
@@ -120,6 +120,14 @@ python-versions = "*"
 beautifulsoup4 = "*"
 
 [[package]]
+name = "cachetools"
+version = "4.2.2"
+description = "Extensible memoizing collections and decorators"
+category = "main"
+optional = false
+python-versions = "~=3.5"
+
+[[package]]
 name = "certifi"
 version = "2020.12.5"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -523,6 +531,103 @@ gitdb = ">=4.0.1,<5"
 typing-extensions = ">=3.7.4.0"
 
 [[package]]
+name = "google-api-core"
+version = "1.30.0"
+description = "Google API client core library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+
+[package.dependencies]
+google-auth = ">=1.25.0,<2.0dev"
+googleapis-common-protos = ">=1.6.0,<2.0dev"
+packaging = ">=14.3"
+protobuf = ">=3.12.0"
+pytz = "*"
+requests = ">=2.18.0,<3.0.0dev"
+six = ">=1.13.0"
+
+[package.extras]
+grpc = ["grpcio (>=1.29.0,<2.0dev)"]
+grpcgcp = ["grpcio-gcp (>=0.2.2)"]
+grpcio-gcp = ["grpcio-gcp (>=0.2.2)"]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.9.0"
+description = "Google API Client Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+google-api-core = ">=1.21.0,<2dev"
+google-auth = ">=1.16.0,<2dev"
+google-auth-httplib2 = ">=0.1.0"
+httplib2 = ">=0.15.0,<1dev"
+six = ">=1.13.0,<2dev"
+uritemplate = ">=3.0.0,<4dev"
+
+[[package]]
+name = "google-auth"
+version = "1.31.0"
+description = "Google Authentication Library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*"
+
+[package.dependencies]
+cachetools = ">=2.0.0,<5.0"
+pyasn1-modules = ">=0.2.1"
+rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
+six = ">=1.9.0"
+
+[package.extras]
+aiohttp = ["requests (>=2.20.0,<3.0.0dev)", "aiohttp (>=3.6.2,<4.0.0dev)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.1.0"
+description = "Google Authentication Library: httplib2 transport"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+google-auth = "*"
+httplib2 = ">=0.15.0"
+six = "*"
+
+[[package]]
+name = "google-oauth"
+version = "1.0.0"
+description = "Google OAuth 2.0 for Server to Server applications implementation. Performs JWT-based access token retrieval for Google APIs."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyopenssl = ">=0.11"
+requests = "*"
+six = "*"
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.53.0"
+description = "Common protobufs used in Google APIs"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+protobuf = ">=3.12.0"
+
+[package.extras]
+grpc = ["grpcio (>=1.0.0)"]
+
+[[package]]
 name = "graphene"
 version = "2.1.8"
 description = "GraphQL Framework for Python"
@@ -592,6 +697,17 @@ python-versions = "*"
 graphql-core = ">=2.2,<3"
 promise = ">=2.2,<3"
 six = ">=1.12"
+
+[[package]]
+name = "httplib2"
+version = "0.19.1"
+description = "A comprehensive HTTP client library."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyparsing = ">=2.4.2,<3"
 
 [[package]]
 name = "icalendar"
@@ -907,12 +1023,42 @@ six = "*"
 test = ["pytest (>=2.7.3)", "pytest-cov", "coveralls", "futures", "pytest-benchmark", "mock"]
 
 [[package]]
+name = "protobuf"
+version = "3.17.3"
+description = "Protocol Buffers"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.9"
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.8.6"
 description = "psycopg2 - Python-PostgreSQL Database Adapter"
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[[package]]
+name = "pyasn1"
+version = "0.4.8"
+description = "ASN.1 types and codecs"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.2.8"
+description = "A collection of ASN.1-based protocols modules."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
 name = "pycodestyle"
@@ -1029,6 +1175,22 @@ python-versions = "*"
 
 [package.dependencies]
 pylint = ">=1.7"
+
+[[package]]
+name = "pyopenssl"
+version = "20.0.1"
+description = "Python wrapper module around the OpenSSL library"
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
+
+[package.dependencies]
+cryptography = ">=3.2"
+six = ">=1.5.2"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+test = ["flaky", "pretend", "pytest (>=3.0.1)"]
 
 [[package]]
 name = "pyparsing"
@@ -1170,6 +1332,17 @@ python-versions = ">=3.5"
 [package.dependencies]
 click = ">=5.0.0"
 redis = ">=3.5.0"
+
+[[package]]
+name = "rsa"
+version = "4.7.2"
+description = "Pure-Python RSA implementation"
+category = "main"
+optional = false
+python-versions = ">=3.5, <4"
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
 
 [[package]]
 name = "ruamel.yaml"
@@ -1414,7 +1587,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "fbebace811c8bfef29e1882bc4549a4d7042c5091caa7e2e54608200b99f4365"
+content-hash = "c6d4a07be06e98412b769ec69678f12ac4475c8393a3c03522d0374cb4d6571a"
 
 [metadata.files]
 aniso8601 = [
@@ -1451,6 +1624,10 @@ black = [
 ]
 bs4 = [
     {file = "bs4-0.0.1.tar.gz", hash = "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"},
+]
+cachetools = [
+    {file = "cachetools-4.2.2-py3-none-any.whl", hash = "sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001"},
+    {file = "cachetools-4.2.2.tar.gz", hash = "sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -1629,6 +1806,30 @@ gitpython = [
     {file = "GitPython-3.1.15-py3-none-any.whl", hash = "sha256:a77824e516d3298b04fb36ec7845e92747df8fcfee9cacc32dd6239f9652f867"},
     {file = "GitPython-3.1.15.tar.gz", hash = "sha256:05af150f47a5cca3f4b0af289b73aef8cf3c4fe2385015b06220cbcdee48bb6e"},
 ]
+google-api-core = [
+    {file = "google-api-core-1.30.0.tar.gz", hash = "sha256:0724d354d394b3d763bc10dfee05807813c5210f0bd9b8e2ddf6b6925603411c"},
+    {file = "google_api_core-1.30.0-py2.py3-none-any.whl", hash = "sha256:92cd9e9f366e84bfcf2524e34d2dc244906c645e731962617ba620da1620a1e0"},
+]
+google-api-python-client = [
+    {file = "google-api-python-client-2.9.0.tar.gz", hash = "sha256:2b5274f06799d80222fd3f20fd4ebcd19f57c009703bd4cf7b00492e7e05e15a"},
+    {file = "google_api_python_client-2.9.0-py2.py3-none-any.whl", hash = "sha256:fb5c28b61327392891bf79ccd0a4edc54c76f6d1f3c10e3821dbdf8a7287f691"},
+]
+google-auth = [
+    {file = "google-auth-1.31.0.tar.gz", hash = "sha256:154f7889c5d679a6f626f36adb12afbd4dbb0a9a04ec575d989d6ba79c4fd65e"},
+    {file = "google_auth-1.31.0-py2.py3-none-any.whl", hash = "sha256:6d47c79b5d09fbc7e8355fd9594cc4cf65fdde5d401c63951eaac4baa1ba2ae1"},
+]
+google-auth-httplib2 = [
+    {file = "google-auth-httplib2-0.1.0.tar.gz", hash = "sha256:a07c39fd632becacd3f07718dfd6021bf396978f03ad3ce4321d060015cc30ac"},
+    {file = "google_auth_httplib2-0.1.0-py2.py3-none-any.whl", hash = "sha256:31e49c36c6b5643b57e82617cb3e021e3e1d2df9da63af67252c02fa9c1f4a10"},
+]
+google-oauth = [
+    {file = "google-oauth-1.0.0.tar.gz", hash = "sha256:08ec0808701e43b9520510722c5b812e7bffbc5f4c2a4a19008b650e4da5ffa8"},
+    {file = "google-oauth-1.0.1.tar.gz", hash = "sha256:5d26c0d995aafd5f4884424159146c81569b9762ed9516d9fd13c7d6c11cc5aa"},
+]
+googleapis-common-protos = [
+    {file = "googleapis-common-protos-1.53.0.tar.gz", hash = "sha256:a88ee8903aa0a81f6c3cec2d5cf62d3c8aa67c06439b0496b49048fb1854ebf4"},
+    {file = "googleapis_common_protos-1.53.0-py2.py3-none-any.whl", hash = "sha256:f6d561ab8fb16b30020b940e2dd01cd80082f4762fa9f3ee670f4419b4b8dbd0"},
+]
 graphene = [
     {file = "graphene-2.1.8-py2.py3-none-any.whl", hash = "sha256:09165f03e1591b76bf57b133482db9be6dac72c74b0a628d3c93182af9c5a896"},
     {file = "graphene-2.1.8.tar.gz", hash = "sha256:2cbe6d4ef15cfc7b7805e0760a0e5b80747161ce1b0f990dfdc0d2cf497c12f9"},
@@ -1644,6 +1845,10 @@ graphql-core = [
 graphql-relay = [
     {file = "graphql-relay-2.0.1.tar.gz", hash = "sha256:870b6b5304123a38a0b215a79eace021acce5a466bf40cd39fa18cb8528afabb"},
     {file = "graphql_relay-2.0.1-py3-none-any.whl", hash = "sha256:ac514cb86db9a43014d7e73511d521137ac12cf0101b2eaa5f0a3da2e10d913d"},
+]
+httplib2 = [
+    {file = "httplib2-0.19.1-py3-none-any.whl", hash = "sha256:2ad195faf9faf079723f6714926e9a9061f694d07724b846658ce08d40f522b4"},
+    {file = "httplib2-0.19.1.tar.gz", hash = "sha256:0b12617eeca7433d4c396a100eaecfa4b08ee99aa881e6df6e257a7aad5d533d"},
 ]
 icalendar = [
     {file = "icalendar-4.0.7-py2.py3-none-any.whl", hash = "sha256:8c35be16c1d0581a276002af883297aeffa8116e366fdce4d5318e1424aa1903"},
@@ -1865,6 +2070,31 @@ prometheus-client = [
 promise = [
     {file = "promise-2.3.tar.gz", hash = "sha256:dfd18337c523ba4b6a58801c164c1904a9d4d1b1747c7d5dbf45b693a49d93d0"},
 ]
+protobuf = [
+    {file = "protobuf-3.17.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ab6bb0e270c6c58e7ff4345b3a803cc59dbee19ddf77a4719c5b635f1d547aa8"},
+    {file = "protobuf-3.17.3-cp27-cp27mu-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:13ee7be3c2d9a5d2b42a1030976f760f28755fcf5863c55b1460fd205e6cd637"},
+    {file = "protobuf-3.17.3-cp35-cp35m-macosx_10_9_intel.whl", hash = "sha256:1556a1049ccec58c7855a78d27e5c6e70e95103b32de9142bae0576e9200a1b0"},
+    {file = "protobuf-3.17.3-cp35-cp35m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:f0e59430ee953184a703a324b8ec52f571c6c4259d496a19d1cabcdc19dabc62"},
+    {file = "protobuf-3.17.3-cp35-cp35m-win32.whl", hash = "sha256:a981222367fb4210a10a929ad5983ae93bd5a050a0824fc35d6371c07b78caf6"},
+    {file = "protobuf-3.17.3-cp35-cp35m-win_amd64.whl", hash = "sha256:6d847c59963c03fd7a0cd7c488cadfa10cda4fff34d8bc8cba92935a91b7a037"},
+    {file = "protobuf-3.17.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:145ce0af55c4259ca74993ddab3479c78af064002ec8227beb3d944405123c71"},
+    {file = "protobuf-3.17.3-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6ce4d8bf0321e7b2d4395e253f8002a1a5ffbcfd7bcc0a6ba46712c07d47d0b4"},
+    {file = "protobuf-3.17.3-cp36-cp36m-win32.whl", hash = "sha256:7a4c97961e9e5b03a56f9a6c82742ed55375c4a25f2692b625d4087d02ed31b9"},
+    {file = "protobuf-3.17.3-cp36-cp36m-win_amd64.whl", hash = "sha256:a22b3a0dbac6544dacbafd4c5f6a29e389a50e3b193e2c70dae6bbf7930f651d"},
+    {file = "protobuf-3.17.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:ffea251f5cd3c0b9b43c7a7a912777e0bc86263436a87c2555242a348817221b"},
+    {file = "protobuf-3.17.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:9b7a5c1022e0fa0dbde7fd03682d07d14624ad870ae52054849d8960f04bc764"},
+    {file = "protobuf-3.17.3-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:8727ee027157516e2c311f218ebf2260a18088ffb2d29473e82add217d196b1c"},
+    {file = "protobuf-3.17.3-cp37-cp37m-win32.whl", hash = "sha256:14c1c9377a7ffbeaccd4722ab0aa900091f52b516ad89c4b0c3bb0a4af903ba5"},
+    {file = "protobuf-3.17.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c56c050a947186ba51de4f94ab441d7f04fcd44c56df6e922369cc2e1a92d683"},
+    {file = "protobuf-3.17.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2ae692bb6d1992afb6b74348e7bb648a75bb0d3565a3f5eea5bec8f62bd06d87"},
+    {file = "protobuf-3.17.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:99938f2a2d7ca6563c0ade0c5ca8982264c484fdecf418bd68e880a7ab5730b1"},
+    {file = "protobuf-3.17.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6902a1e4b7a319ec611a7345ff81b6b004b36b0d2196ce7a748b3493da3d226d"},
+    {file = "protobuf-3.17.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4ffbd23640bb7403574f7aff8368e2aeb2ec9a5c6306580be48ac59a6bac8bde"},
+    {file = "protobuf-3.17.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:26010f693b675ff5a1d0e1bdb17689b8b716a18709113288fead438703d45539"},
+    {file = "protobuf-3.17.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e76d9686e088fece2450dbc7ee905f9be904e427341d289acbe9ad00b78ebd47"},
+    {file = "protobuf-3.17.3-py2.py3-none-any.whl", hash = "sha256:2bfb815216a9cd9faec52b16fd2bfa68437a44b67c56bee59bc3926522ecb04e"},
+    {file = "protobuf-3.17.3.tar.gz", hash = "sha256:72804ea5eaa9c22a090d2803813e280fb273b62d5ae497aaf3553d141c4fdd7b"},
+]
 psycopg2-binary = [
     {file = "psycopg2-binary-2.8.6.tar.gz", hash = "sha256:11b9c0ebce097180129e422379b824ae21c8f2a6596b159c7659e2e5a00e1aa0"},
     {file = "psycopg2_binary-2.8.6-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl", hash = "sha256:d14b140a4439d816e3b1229a4a525df917d6ea22a0771a2a78332273fd9528a4"},
@@ -1901,6 +2131,36 @@ psycopg2-binary = [
     {file = "psycopg2_binary-2.8.6-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7312e931b90fe14f925729cde58022f5d034241918a5c4f9797cac62f6b3a9dd"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-win32.whl", hash = "sha256:6422f2ff0919fd720195f64ffd8f924c1395d30f9a495f31e2392c2efafb5056"},
     {file = "psycopg2_binary-2.8.6-cp39-cp39-win_amd64.whl", hash = "sha256:15978a1fbd225583dd8cdaf37e67ccc278b5abecb4caf6b2d6b8e2b948e953f6"},
+]
+pyasn1 = [
+    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
+    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
+    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
+    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
+    {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
+    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
+    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
+    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
+    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
+    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
+    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
+    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
+    {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
+]
+pyasn1-modules = [
+    {file = "pyasn1-modules-0.2.8.tar.gz", hash = "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e"},
+    {file = "pyasn1_modules-0.2.8-py2.4.egg", hash = "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199"},
+    {file = "pyasn1_modules-0.2.8-py2.5.egg", hash = "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"},
+    {file = "pyasn1_modules-0.2.8-py2.6.egg", hash = "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb"},
+    {file = "pyasn1_modules-0.2.8-py2.7.egg", hash = "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8"},
+    {file = "pyasn1_modules-0.2.8-py2.py3-none-any.whl", hash = "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"},
+    {file = "pyasn1_modules-0.2.8-py3.1.egg", hash = "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d"},
+    {file = "pyasn1_modules-0.2.8-py3.2.egg", hash = "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45"},
+    {file = "pyasn1_modules-0.2.8-py3.3.egg", hash = "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4"},
+    {file = "pyasn1_modules-0.2.8-py3.4.egg", hash = "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811"},
+    {file = "pyasn1_modules-0.2.8-py3.5.egg", hash = "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed"},
+    {file = "pyasn1_modules-0.2.8-py3.6.egg", hash = "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0"},
+    {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
@@ -1989,6 +2249,10 @@ pylint-django = [
 pylint-plugin-utils = [
     {file = "pylint-plugin-utils-0.6.tar.gz", hash = "sha256:57625dcca20140f43731311cd8fd879318bf45a8b0fd17020717a8781714a25a"},
     {file = "pylint_plugin_utils-0.6-py3-none-any.whl", hash = "sha256:2f30510e1c46edf268d3a195b2849bd98a1b9433229bb2ba63b8d776e1fc4d0a"},
+]
+pyopenssl = [
+    {file = "pyOpenSSL-20.0.1-py2.py3-none-any.whl", hash = "sha256:818ae18e06922c066f777a33f1fca45786d85edfe71cd043de6379337a7f274b"},
+    {file = "pyOpenSSL-20.0.1.tar.gz", hash = "sha256:4c231c759543ba02560fcd2480c48dcec4dae34c9da7d3747c508227e0624b51"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -2111,6 +2375,10 @@ requests-oauthlib = [
 rq = [
     {file = "rq-1.8.0-py2.py3-none-any.whl", hash = "sha256:d861f1e794b595ae83f7b919d0c56d7102bc18f4f7b71395446d60d70344577c"},
     {file = "rq-1.8.0.tar.gz", hash = "sha256:2a253385bec82f0e723ad25fb547d3892900a94b3c3acc53514c4bd74897cb69"},
+]
+rsa = [
+    {file = "rsa-4.7.2-py3-none-any.whl", hash = "sha256:78f9a9bf4e7be0c5ded4583326e7461e3a3c5aae24073648b4bdfa797d78c9d2"},
+    {file = "rsa-4.7.2.tar.gz", hash = "sha256:9d689e6ca1b3038bc82bf8d23e944b6b6037bc02301a574935b2dd946e0353b9"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.17.4-py3-none-any.whl", hash = "sha256:ac79fb25f5476e8e9ed1c53b8a2286d2c3f5dde49eb37dbcee5c7eb6a8415a22"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ nautobot = "*"
 bs4 = "^0.0.1"
 pydantic = "^1.8.1"
 circuit-maintenance-parser = "^1.1.0"
+google-api-python-client = "^2.9.0"
+google-oauth = "^1.0.0"
 
 [tool.poetry.dev-dependencies]
 invoke = "*"


### PR DESCRIPTION
# TODO

- [x] Create an abstract `EmailSource` class that will concentrate some methods and attributes valid either for IMAP or Gmail API. This is more concrete than the `Source` that could eventually fetch directly REST API with JSON data (for instance)
- [x] Validate that the API calls works once we could implement "Delegate domain-wide authority"  
- [x] Implement the Retrieve emails logic and looks for synergies with the IMAP method to simplify both
- [x] Define how the Service Account works and all the steps the user has to do in Google to make it work to add to Readme
- [x] Extend testing for the new class


![image](https://user-images.githubusercontent.com/15998111/122169603-e26d9b80-ce7d-11eb-880e-038bf5032cc8.png)
