### PR TITLE
When retrieving Notifications via email, we include notifications received on the same day as the last notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - #51: Improve Development Environment and upgrade Nautobot version to 1.1.0
 
+### Fixed
+
+- #53: The **SINCE** filter to receive email notifications is extended on day in the past in order to get notifications from the same day as the last notifications stored.
+
 ## v0.1.7 - 2021-07-27
 
 ### Added

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -224,7 +224,8 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
         return None
 
     if not created:
-        logger.log_warning(message=f"Raw notification '{raw_entry.subject}' already existed with id {raw_entry.pk}")
+        # If the RawNotification was already created, we ignore it.
+        logger.log_debug(message=f"Raw notification '{raw_entry.subject}' already existed with id {raw_entry.pk}")
         return None
 
     logger.log_success(raw_entry, message="Raw notification created.")

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -8,7 +8,6 @@ import email
 import json
 import traceback
 from urllib.parse import urlparse
-from email.utils import mktime_tz, parsedate_tz
 from typing import Iterable, Optional, TypeVar, Type, Tuple, Dict, Union
 
 import imaplib
@@ -58,7 +57,9 @@ class Source(BaseModel):
         """Method to get an identifier of the related account."""
         raise NotImplementedError
 
-    def receive_notifications(self, job_logger: Job, since: int = None) -> Iterable[MaintenanceNotification]:
+    def receive_notifications(
+        self, job_logger: Job, since_timestamp: datetime.datetime = None
+    ) -> Iterable[MaintenanceNotification]:
         """Function to retrieve notifications since one moment in time.
 
         The `MaintenanceNotification` attributes will contains these attributes:
@@ -323,16 +324,11 @@ class IMAP(EmailSource):
         self.open_session()
         self.close_session()
 
-    def fetch_email(self, job_logger: Job, msg_id: bytes, since: Optional[int]) -> Optional[MaintenanceNotification]:
+    def fetch_email(self, job_logger: Job, msg_id: bytes) -> Optional[MaintenanceNotification]:
         """Fetch an specific email ID."""
         _, data = self.session.fetch(msg_id, "(RFC822)")
         raw_email_string = data[0][1].decode("utf-8")
         email_message = email.message_from_string(raw_email_string)
-
-        if since:
-            if mktime_tz(parsedate_tz(email_message["Date"])) < since:
-                job_logger.log_info(message=f"'{email_message['Subject']}' email is old, so not taking into account.")
-                return None
 
         return self.process_email(job_logger, email_message)
 
@@ -378,7 +374,9 @@ class IMAP(EmailSource):
             provider_type=provider_type,
         )
 
-    def receive_notifications(self, job_logger: Job, since: int = None) -> Iterable[MaintenanceNotification]:
+    def receive_notifications(
+        self, job_logger: Job, since_timestamp: datetime.datetime = None
+    ) -> Iterable[MaintenanceNotification]:
         """Retrieve emails since an specific time, if provided."""
         self.open_session()
 
@@ -389,8 +387,8 @@ class IMAP(EmailSource):
         # Maybe extend filtering options, for instance, to discard some type of notifications
         msg_ids = []
         since_date = ""
-        if since:
-            since_txt = datetime.datetime.fromtimestamp(since).strftime("%d-%b-%Y")
+        if since_timestamp:
+            since_txt = since_timestamp.strftime("%d-%b-%Y")
             since_date = f'SINCE "{since_txt}"'
 
         if self.emails_to_fetch:
@@ -410,7 +408,7 @@ class IMAP(EmailSource):
 
         received_notifications = []
         for msg_id in msg_ids:
-            raw_notification = self.fetch_email(job_logger, msg_id, since)
+            raw_notification = self.fetch_email(job_logger, msg_id)
             if raw_notification:
                 received_notifications.append(raw_notification)
 
@@ -466,7 +464,7 @@ class GmailAPI(EmailSource):
 
         return b""
 
-    def fetch_email(self, job_logger: Job, msg_id: bytes, since: Optional[int]) -> Optional[MaintenanceNotification]:
+    def fetch_email(self, job_logger: Job, msg_id: bytes) -> Optional[MaintenanceNotification]:
         """Fetch an specific email ID.
 
         See data format:  https://developers.google.com/gmail/api/reference/rest/v1/users.messages#Message
@@ -475,10 +473,10 @@ class GmailAPI(EmailSource):
             self.service.users().messages().get(userId=self.account, id=msg_id).execute()  # pylint: disable=no-member
         )
 
-        return self.process_email(job_logger, received_email, msg_id, since)
+        return self.process_email(job_logger, received_email, msg_id)
 
     def process_email(  # pylint: disable=too-many-locals
-        self, job_logger: Job, received_email: Dict, msg_id: bytes, since: Optional[int]
+        self, job_logger: Job, received_email: Dict, msg_id: bytes
     ) -> Optional[MaintenanceNotification]:
         """Helper method for the fetch_email() method."""
         email_subject = ""
@@ -489,11 +487,6 @@ class GmailAPI(EmailSource):
                 email_subject = header["value"]
             elif header.get("name") == self.source_header:
                 email_source = header["value"]
-
-        if since:
-            if int(received_email["internalDate"]) < since:
-                job_logger.log_info(message=f"'{email_subject}' email is old, so not taking into account.")
-                return None
 
         email_source_before = email_source
         email_source = self.extract_email_source(email_source)
@@ -540,14 +533,16 @@ class GmailAPI(EmailSource):
             provider_type=provider_type,
         )
 
-    def receive_notifications(self, job_logger: Job, since: int = None) -> Iterable[MaintenanceNotification]:
+    def receive_notifications(
+        self, job_logger: Job, since_timestamp: datetime.datetime = None
+    ) -> Iterable[MaintenanceNotification]:
         """Retrieve emails since an specific time, if provided."""
         self.load_credentials()
         self.build_service()
 
         search_criteria = ""
-        if since:
-            since_txt = datetime.datetime.fromtimestamp(since).strftime("%Y/%b/%d")
+        if since_timestamp:
+            since_txt = since_timestamp.strftime("%Y/%b/%d")
             search_criteria = f'after:"{since_txt}"'
 
         # If source_header is not "from" but some other custom header such as X-Original-Sender,
@@ -567,7 +562,7 @@ class GmailAPI(EmailSource):
 
         received_notifications = []
         for msg_id in msg_ids:
-            raw_notification = self.fetch_email(job_logger, msg_id, since)
+            raw_notification = self.fetch_email(job_logger, msg_id)
             if raw_notification:
                 received_notifications.append(raw_notification)
 
@@ -634,8 +629,10 @@ def get_notifications(
     for notification_source in notification_sources:
         try:
             if since:
-                since_txt = datetime.datetime.fromtimestamp(since).strftime("%d-%b-%Y")
+                since_date = datetime.datetime.fromtimestamp(since)
+                since_txt = since_date.strftime("%d-%b-%Y")
             else:
+                since_date = None
                 since_txt = "always"
 
             try:
@@ -653,7 +650,12 @@ def get_notifications(
                 continue
 
             if source.validate_providers(job_logger, notification_source, since_txt):
-                raw_notifications = source.receive_notifications(job_logger, since)
+                if since_date:
+                    # When using the SINCE filter, we add one extra day to check for notifications received
+                    # on the very same day since last notification.
+                    since_date -= datetime.timedelta(days=1)
+
+                raw_notifications = source.receive_notifications(job_logger, since_date)
                 received_notifications.extend(raw_notifications)
 
                 if not raw_notifications:

--- a/nautobot_circuit_maintenance/tests/test_sources.py
+++ b/nautobot_circuit_maintenance/tests/test_sources.py
@@ -1,4 +1,4 @@
-"""Test sourcess utils."""
+"""Test sources utils."""
 import base64
 from email.message import EmailMessage
 import json
@@ -629,7 +629,7 @@ class TestGmailAPISource(TestCase):
             "internalDate": 1000,
         }
 
-        notification = source.process_email(job, received_email, msg_id="abc", since=0)
+        notification = source.process_email(job, received_email, msg_id=b"abc")
         self.assertIsNotNone(notification)
         self.assertEqual(notification.source, source.name)
         self.assertEqual(notification.sender, "user@example.com")
@@ -660,7 +660,7 @@ class TestGmailAPISource(TestCase):
             "internalDate": 1000,
         }
 
-        notification = source.process_email(job, received_email, msg_id="abc", since=0)
+        notification = source.process_email(job, received_email, msg_id=b"abc")
         self.assertIsNotNone(notification)
         self.assertEqual(notification.source, source.name)
         self.assertEqual(notification.sender, "user@example.com")


### PR DESCRIPTION
Addresses #46 

The suggested idea relies on the `get_or_create` logic used for adding new `RawNotifications`. Because getting a duplicated one is not a big problem, we just ignore it (decreased logger level from `warning` to `debug`).

So, in order to get notifications received on the same day as the last notification stored (this approach was introduced to limit the number of emails received), the only change is to **decrease the reference date by one**, so obviously we will get some notifications already processed, but we just skip them and move to new notifications.

Apart, this PR cleans some duplicated check on the email once the filter is already in place, making the code simpler.