### PR TITLE
Add plugin option to define the number of days back for notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
-- #51: Add a Custom Field in Provider, `provider_parser_circuit_maintenances` to allow custom mapping of the provider type class used from the `circuit-maintenance-parser` library
+- #51: Add a Custom Field in Provider, `provider_parser_circuit_maintenances` to allow custom mapping of the provider type class used from the `circuit-maintenance-parser` library.
+- #54: Add a plugin option to define the number of days back to retrieve notifications on the first run of the plugin, before it has one previous notification as a reference.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,10 @@ Once installed, the plugin needs to be enabled in your `configuration.py`.
 PLUGINS = ["nautobot_circuit_maintenance"]
 ```
 
-Extra configuration to define notification sources is defined in the [Usage](#Usage) section.
-
 ```py
 PLUGINS_CONFIG = {
     "nautobot_circuit_maintenance": {
+        "raw_notifications": {"initial_days_since": 100},
         "notification_sources": [
             {
               ...
@@ -40,6 +39,15 @@ PLUGINS_CONFIG = {
     }
 }
 ```
+
+In the `raw_notifications` section, you can define:
+
+- `initial_days_since`: define how many days back the plugin will check for `RawNotification`s for each
+  `NotificationSource`, in order to limit the number of notifications to be processed on the first run of the plugin.
+  In subsequent runs, the last notification date will be used as the reference to limit. If not defined, it defaults to
+  **365 days**.
+
+The `notification_sources` have custom definition depending on the `Source` type, and are defined in the [Usage](#Usage) section.
 
 ## Usage
 

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -241,6 +241,7 @@ PLUGINS = ["nautobot_circuit_maintenance"]
 # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
 PLUGINS_CONFIG = {
     "nautobot_circuit_maintenance": {
+        "raw_notifications": {"initial_days_since": 100},
         "notification_sources": [
             {
                 "name": "my imap source",
@@ -260,7 +261,7 @@ PLUGINS_CONFIG = {
                 "account": os.environ.get("CM_NS_3_ACCOUNT", ""),
                 "credentials_file": os.environ.get("CM_NS_3_CREDENTIALS_FILE", ""),
             },
-        ]
+        ],
     }
 }
 

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -18,7 +18,8 @@ from .sources import get_notifications, MaintenanceNotification
 
 
 # pylint: disable=broad-except
-PLUGIN_SETTINGS = settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]
+PLUGIN_SETTINGS = settings.PLUGINS_CONFIG.get("nautobot_circuit_maintenance", {})
+MAX_INITIAL_DAYS_SINCE = 365
 
 
 def create_circuit_maintenance(
@@ -268,16 +269,20 @@ class HandleCircuitMaintenanceNotifications(Job):
         # Latest retrieved notification will limit the scope of notifications to retrieve
         last_raw_notification = RawNotification.objects.last()
         if last_raw_notification:
-            last_time_processed = last_raw_notification.date.timestamp()
-            self.log_info(message=f"Processing notifications since {last_raw_notification.date}")
+            since_reference = last_raw_notification.date.timestamp()
         else:
-            last_time_processed = None
+            since_reference = datetime.datetime.utcnow() - datetime.timedelta(
+                days=PLUGIN_SETTINGS.get("raw_notifications", {}).get("initial_days_since", MAX_INITIAL_DAYS_SINCE)
+            )
+            since_reference = int(since_reference.timestamp())
+
+        self.log_info(message=f"Processing notifications since {since_reference}")
 
         try:
             notifications = get_notifications(
                 job_logger=self,
                 notification_sources=notification_sources,
-                since=last_time_processed,
+                since=since_reference,
             )
             if not notifications:
                 self.log_info(message="No notifications received.")

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -626,17 +626,14 @@ class GmailAPIServiceAccount(GmailAPI):
 
 
 def get_notifications(
-    job_logger: Job, notification_sources: Iterable[NotificationSource], since: int = None
+    job_logger: Job, notification_sources: Iterable[NotificationSource], since: int
 ) -> Iterable[MaintenanceNotification]:
     """Method to fetch notifications from multiple sources and return MaintenanceNotification objects."""
     received_notifications = []
 
     for notification_source in notification_sources:
         try:
-            if since:
-                since_txt = datetime.datetime.fromtimestamp(since).strftime("%d-%b-%Y")
-            else:
-                since_txt = "always"
+            since_txt = datetime.datetime.fromtimestamp(since).strftime("%d-%b-%Y")
 
             try:
                 source = Source.init(name=notification_source.name)

--- a/nautobot_circuit_maintenance/tests/test_sources.py
+++ b/nautobot_circuit_maintenance/tests/test_sources.py
@@ -5,6 +5,7 @@ import json
 import os
 from unittest.mock import Mock, patch
 import uuid
+import datetime
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
@@ -227,7 +228,7 @@ class TestIMAPSource(TestCase):
         notification_source = NotificationSource.objects.get(name=SOURCE_IMAP["name"])
         notification_source.providers.set([])
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        res = get_notifications(self.logger, NotificationSource.objects.all(), 0)
         self.assertEqual([], res)
         source_name = SOURCE_IMAP["name"]
         self.logger.log_warning.assert_called_with(
@@ -244,20 +245,21 @@ class TestIMAPSource(TestCase):
         notification_source.providers.add(original_provider)
         notification_source.providers.add(new_provider)
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        since = 0
+        res = get_notifications(self.logger, NotificationSource.objects.all(), since)
         self.assertEqual([], res)
 
         self.logger.log_warning.assert_called_with(
             message=f"Skipping {new_provider.name} because these providers have no email configured."
         )
         self.logger.log_info.assert_called_with(
-            message=f"No notifications received for {original_provider}, {new_provider} since always from {notification_source.name}"
+            message=f"No notifications received for {original_provider}, {new_provider} since {datetime.datetime.fromtimestamp(since).strftime('%d-%b-%Y')} from {notification_source.name}"
         )
 
     def test_get_notifications_no_imap_account(self):
         """Test get_notifications without IMAP account."""
         del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["account"]
-        get_notifications(self.logger, NotificationSource.objects.all())
+        get_notifications(self.logger, NotificationSource.objects.all(), 0)
 
         self.logger.log_warning.assert_called_with(
             message=f"Notification Source {SOURCE_IMAP['name']} is not matching class expectations: 1 validation error for IMAP\naccount\n  none is not an allowed value (type=type_error.none.not_allowed)"
@@ -271,7 +273,7 @@ class TestIMAPSource(TestCase):
 
         mock_receive_notifications.return_value = [notification]
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        res = get_notifications(self.logger, NotificationSource.objects.all(), 0)
 
         self.assertEqual(1, len(res))
         self.logger.log_warning.assert_not_called()
@@ -284,7 +286,7 @@ class TestIMAPSource(TestCase):
 
         mock_receive_notifications.return_value = [notification, notification]
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        res = get_notifications(self.logger, NotificationSource.objects.all(), 0)
 
         self.assertEqual(2, len(res))
         self.logger.log_warning.assert_not_called()
@@ -476,7 +478,7 @@ class TestGmailAPISource(TestCase):
         notification_source = NotificationSource.objects.get(name=SOURCE_GMAIL_API_SERVICE_ACCOUNT["name"])
         notification_source.providers.set([])
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        res = get_notifications(self.logger, NotificationSource.objects.all(), 0)
         self.assertEqual([], res)
         source_name = SOURCE_GMAIL_API_SERVICE_ACCOUNT["name"]
         self.logger.log_warning.assert_called_with(
@@ -493,20 +495,21 @@ class TestGmailAPISource(TestCase):
         notification_source.providers.add(original_provider)
         notification_source.providers.add(new_provider)
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        since = 0
+        res = get_notifications(self.logger, NotificationSource.objects.all(), since)
         self.assertEqual([], res)
 
         self.logger.log_warning.assert_called_with(
             message=f"Skipping {new_provider.name} because these providers have no email configured."
         )
         self.logger.log_info.assert_called_with(
-            message=f"No notifications received for {original_provider}, {new_provider} since always from {notification_source.name}"
+            message=f"No notifications received for {original_provider}, {new_provider} since {datetime.datetime.fromtimestamp(since).strftime('%d-%b-%Y')} from {notification_source.name}"
         )
 
     def test_get_notifications_no_account(self):
         """Test get_notifications without account."""
         del settings.PLUGINS_CONFIG["nautobot_circuit_maintenance"]["notification_sources"][0]["account"]
-        get_notifications(self.logger, NotificationSource.objects.all())
+        get_notifications(self.logger, NotificationSource.objects.all(), 0)
 
         self.logger.log_warning.assert_called_with(
             message=f"Notification Source {SOURCE_GMAIL_API_SERVICE_ACCOUNT['name']} is not matching class expectations: 1 validation error for GmailAPIServiceAccount\naccount\n  none is not an allowed value (type=type_error.none.not_allowed)"
@@ -520,7 +523,7 @@ class TestGmailAPISource(TestCase):
 
         mock_receive_notifications.return_value = [notification]
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        res = get_notifications(self.logger, NotificationSource.objects.all(), 0)
 
         self.assertEqual(1, len(res))
         self.logger.log_warning.assert_not_called()
@@ -533,7 +536,7 @@ class TestGmailAPISource(TestCase):
 
         mock_receive_notifications.return_value = [notification, notification]
 
-        res = get_notifications(self.logger, NotificationSource.objects.all())
+        res = get_notifications(self.logger, NotificationSource.objects.all(), 0)
 
         self.assertEqual(2, len(res))
         self.logger.log_warning.assert_not_called()


### PR DESCRIPTION
Addresses #52 

Before, on the first run of the plugin, there was no limit to look back for notification from Sources, now there is a default max of 365 days, and also a customizable option to increase or decrease it, in order to not overwhelm the plugin on the first run.