### PR TITLE
Clean IMAP session if authentication fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.1.11
+
+### Fixed
+
+- #76: Fix IMAP authentication logic that was not cleaning session after authentication failure.
+
 ## v0.1.10 - 2021-09-01
 
 ### Added
@@ -10,7 +16,6 @@
 ### Fixed
 
 - #74: Fix Gmail API `after` format.
-- #76: Fix IMAP authentication logic that was not cleaning session after authentication failure.
 
 ## v0.1.9 - 2021-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - #74: Fix Gmail API `after` format.
+- #76: Fix IMAP authentication logic that was not cleaning session after authentication failure.
 
 ## v0.1.9 - 2021-08-12
 

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -314,10 +314,7 @@ class IMAP(EmailSource):
         if not self.session:
             self.session = imaplib.IMAP4_SSL(self.imap_server, self.imap_port)
         if self.session.state == "NONAUTH":
-            try:
-                self.session.login(self.account, self.password)
-            except imaplib.IMAP4.error:
-                raise
+            self.session.login(self.account, self.password)
 
     def close_session(self):
         """Close session to IMAP server.

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -309,7 +309,11 @@ class IMAP(EmailSource):
         """Open session to IMAP server."""
         if not self.session:
             self.session = imaplib.IMAP4_SSL(self.imap_server, self.imap_port)
-            self.session.login(self.account, self.password)
+            try:
+                self.session.login(self.account, self.password)
+            except imaplib.IMAP4.error:
+                self.session = None
+                raise
 
     def close_session(self):
         """Close session to IMAP server."""

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -307,17 +307,23 @@ class IMAP(EmailSource):
         arbitrary_types_allowed = True
 
     def open_session(self):
-        """Open session to IMAP server."""
+        """Open session to IMAP server.
+
+        See states: https://github.com/python/cpython/blob/3.9/Lib/imaplib.py#L58
+        """
         if not self.session:
             self.session = imaplib.IMAP4_SSL(self.imap_server, self.imap_port)
+        if self.session.state == "NONAUTH":
             try:
                 self.session.login(self.account, self.password)
             except imaplib.IMAP4.error:
-                self.session = None
                 raise
 
     def close_session(self):
-        """Close session to IMAP server."""
+        """Close session to IMAP server.
+
+        See states: https://github.com/python/cpython/blob/3.9/Lib/imaplib.py#L58
+        """
         if self.session:
             if self.session.state == "SELECTED":
                 self.session.close()


### PR DESCRIPTION
Testing IMAP authentication was not cleaning the session after a failure, so next test was succeeding because the session, even not authenticated, was avaialble.