### PR TITLE
Add support for `extra_scopes` on Gmail notification sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.1.10
 
+### Added
+
+- #78: Add optional `extra_scopes` config parameter to use with Gmail notification sources.
+
 ### Fixed
 
 - #74: Fix Gmail API `after` format.

--- a/README.md
+++ b/README.md
@@ -115,9 +115,10 @@ There are 2 extra required attributes:
 - `account`: Identifier (i.e. email address) to access via OAuth or to impersonate as service account.
 - `credentials_file`: JSON file containing all the necessary data to identify the API integration (see below).
 
-There is also one optional attribute:
+There are also two optional attributes:
 
 - `source_header`: Specify a particular email header to use to identify the source of a particular notification and assign it to the appropriate provider. If unset, `From` will be used, but if your emails are not received directly from the provider but instead pass through a mailing list or alias, you might need to set this to a different value such as `X-Original-Sender` instead.
+- `extra_scopes`: Specify a list of additional Google OAuth2 scopes to request access to in addition to GMail API access.
 
 ```py
 PLUGINS_CONFIG = {
@@ -128,7 +129,8 @@ PLUGINS_CONFIG = {
                 "account": os.getenv("CM_NS_1_ACCOUNT", ""),
                 "credentials_file": os.getenv("CM_NS_1_CREDENTIALS_FILE", ""),
                 "url": os.getenv("CM_NS_1_URL", ""),
-                "source_header": os.getenv("CM_NS_1_SOURCE_HEADER", "From"),  # optional
+                "source_header": os.getenv("CM_NS_1_SOURCE_HEADER", "From"),          # optional
+                "extra_scopes": ["https://www.googleapis.com/auth/calendar.events"],  # optional
             }
         ]
     }

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -163,6 +163,7 @@ class Source(BaseModel):
                     account=config.get("account"),
                     credentials_file=creds_filename,
                     source_header=config.get("source_header", "From"),
+                    extra_scopes=config.get("extra_scopes", []),
                 )
 
         raise ValueError(
@@ -443,6 +444,8 @@ class GmailAPI(EmailSource):
 
     SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
+    extra_scopes: Iterable[str] = []
+
     class Config:
         """Pydantic BaseModel config."""
 
@@ -643,7 +646,7 @@ class GmailAPIServiceAccount(GmailAPI):
         """Load Gmail API Service Account credentials."""
         if not self.credentials:
             self.credentials = service_account.Credentials.from_service_account_file(self.credentials_file)
-            self.credentials = self.credentials.with_scopes(self.SCOPES)
+            self.credentials = self.credentials.with_scopes(self.SCOPES + self.extra_scopes)
             self.credentials = self.credentials.with_subject(self.account)
             self.credentials.refresh(Request())
 

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -8,7 +8,7 @@ import email
 import json
 import traceback
 from urllib.parse import urlparse
-from typing import Iterable, Optional, TypeVar, Type, Tuple, Dict, Union
+from typing import Iterable, List, Optional, TypeVar, Type, Tuple, Dict, Union
 
 import imaplib
 
@@ -444,7 +444,7 @@ class GmailAPI(EmailSource):
 
     SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
-    extra_scopes: Iterable[str] = []
+    extra_scopes: List[str] = []
 
     class Config:
         """Pydantic BaseModel config."""

--- a/nautobot_circuit_maintenance/views.py
+++ b/nautobot_circuit_maintenance/views.py
@@ -332,7 +332,7 @@ def google_authorize(request, slug):
     notification_source = models.NotificationSource.objects.get(slug=slug)
     source = Source.init(name=notification_source.name)
     request.session["CLIENT_SECRETS_FILE"] = source.credentials_file
-    request.session["SCOPES"] = source.SCOPES
+    request.session["SCOPES"] = source.SCOPES + source.extra_scopes
     request.session["SOURCE_SLUG"] = slug
 
     # Create flow instance to manage the OAuth 2.0 Authorization Grant Flow steps.


### PR DESCRIPTION
I have a custom plugin that builds atop nautobot-circuit-maintenance to automatically update a Google Calendar when a CircuitMaintenance is created or updated. Rather than setting up a separate OAuth2 integration for Google Calendar, it'd be really useful to just piggyback atop the existing NotificationSource OAuth setup. Towards this end, this PR adds an optional `extra_scopes` plugin config item that can be used to define additional access scopes to request when setting up OAuth. I've tested it in our user's environment and it meets my needs.