### PR TITLE
Issue 75 avoid maintenance id collisions

### DIFF
--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -151,7 +151,7 @@ def update_circuit_maintenance(
 
 def process_parsed_notification(logger: Job, parsed_notification: ParsedNotification, raw_entry: RawNotification):
     """Processes a Parsed Notification, creating or updating the related Circuit Maintenance."""
-    maintenance_id = str(parsed_notification.maintenance_id)
+    maintenance_id = f"{raw_entry.provider.slug}-{parsed_notification.maintenance_id}"
     circuit_maintenance_entry = CircuitMaintenance.objects.filter(name=maintenance_id).last()
 
     if circuit_maintenance_entry:

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from circuit_maintenance_parser import ParsingError, init_provider
 from nautobot.circuits.models import Circuit, Provider
 from nautobot.extras.jobs import Job, BooleanVar
+from nautobot.extras.models import CustomField
 from nautobot_circuit_maintenance.models import (
     CircuitImpact,
     CircuitMaintenance,
@@ -23,11 +24,9 @@ MAX_INITIAL_DAYS_SINCE = 365
 
 
 def create_circuit_maintenance(
-    logger: Job, maintenance_id: str, parsed_notification: ParsedNotification
+    logger: Job, maintenance_id: str, parsed_notification: ParsedNotification, provider: Provider
 ) -> CircuitMaintenance:
     """Handles the creation of a new circuit maintenance."""
-    provider = Provider.objects.filter(slug=parsed_notification.slug()).last()
-
     circuit_maintenance_entry = CircuitMaintenance.objects.create(
         name=maintenance_id,
         start_time=datetime.datetime.fromtimestamp(parsed_notification.start),
@@ -38,7 +37,7 @@ def create_circuit_maintenance(
     logger.log_success(obj=circuit_maintenance_entry, message="Created Circuit Maintenance.")
 
     for circuit in parsed_notification.circuits:
-        circuit_entry = Circuit.objects.filter(cid=circuit.circuit_id, provider=provider.pk).last()
+        circuit_entry = Circuit.objects.filter(cid=circuit.circuit_id, provider=provider).last()
         if circuit_entry:
             circuit_impact_entry = CircuitImpact.objects.create(
                 maintenance=circuit_maintenance_entry,
@@ -77,10 +76,9 @@ def update_circuit_maintenance(
     circuit_maintenance_entry: CircuitMaintenance,
     maintenance_id: str,
     parsed_notification: ParsedNotification,
+    provider: Provider,
 ):  # pylint: disable=too-many-locals
     """Handles the update of an existent circuit maintenance."""
-    provider = Provider.objects.filter(slug=parsed_notification.slug()).last()
-
     circuit_maintenance_entry.description = parsed_notification.summary
     circuit_maintenance_entry.status = parsed_notification.status
     circuit_maintenance_entry.start_time = datetime.datetime.fromtimestamp(parsed_notification.start)
@@ -149,15 +147,17 @@ def update_circuit_maintenance(
     logger.log_info(obj=circuit_maintenance_entry, message=f"Updated Circuit Maintenance {maintenance_id}")
 
 
-def process_parsed_notification(logger: Job, parsed_notification: ParsedNotification, raw_entry: RawNotification):
+def process_parsed_notification(
+    logger: Job, parsed_notification: ParsedNotification, raw_entry: RawNotification, provider: Provider
+):
     """Processes a Parsed Notification, creating or updating the related Circuit Maintenance."""
     maintenance_id = f"{raw_entry.provider.slug}-{parsed_notification.maintenance_id}"
     circuit_maintenance_entry = CircuitMaintenance.objects.filter(name=maintenance_id).last()
 
     if circuit_maintenance_entry:
-        update_circuit_maintenance(logger, circuit_maintenance_entry, maintenance_id, parsed_notification)
+        update_circuit_maintenance(logger, circuit_maintenance_entry, maintenance_id, parsed_notification, provider)
     else:
-        circuit_maintenance_entry = create_circuit_maintenance(logger, maintenance_id, parsed_notification)
+        circuit_maintenance_entry = create_circuit_maintenance(logger, maintenance_id, parsed_notification, provider)
 
     # Insert parsed notification in DB
     parsed_entry = ParsedNotification.objects.create(
@@ -185,9 +185,15 @@ def process_raw_notification(  # pylint: disable=too-many-branches
         )
         return None
 
+    provider_type = (
+        provider.get_custom_fields().get(CustomField.objects.get(name="provider_parser_circuit_maintenances"))
+        or provider.slug
+    )
+    provider_type = provider_type.lower()
+
     raw_payload = b""
     for raw_payload in notification.raw_payloads:
-        parser = init_provider(raw=raw_payload, provider_type=notification.provider_type)
+        parser = init_provider(raw=raw_payload, provider_type=provider_type)
         if not parser:
             logger.log_warning(message=f"Notification Parser not found for {notification.provider_type}")
             return None
@@ -236,7 +242,7 @@ def process_raw_notification(  # pylint: disable=too-many-branches
 
     for parsed_notification in parsed_notifications:
         try:
-            process_parsed_notification(logger, parsed_notification, raw_entry)
+            process_parsed_notification(logger, parsed_notification, raw_entry, provider)
             # Update raw notification as properly parsed
             raw_entry.parsed = True
             raw_entry.save()

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from circuit_maintenance_parser import ParsingError, init_provider
 from nautobot.circuits.models import Circuit, Provider
 from nautobot.extras.jobs import Job, BooleanVar
-from nautobot.extras.models import CustomField
 from nautobot_circuit_maintenance.models import (
     CircuitImpact,
     CircuitMaintenance,
@@ -185,11 +184,7 @@ def process_raw_notification(  # pylint: disable=too-many-branches
         )
         return None
 
-    provider_type = (
-        provider.get_custom_fields().get(CustomField.objects.get(name="provider_parser_circuit_maintenances"))
-        or provider.slug
-    )
-    provider_type = provider_type.lower()
+    provider_type = provider.cf.get("provider_parser_circuit_maintenances", "").lower() or provider.slug
 
     raw_payload = b""
     for raw_payload in notification.raw_payloads:


### PR DESCRIPTION
This PR is addressing 2 issues:
* #75 So the maintenance_id in the plugin now it's a composition of the `f"{provider.slug}-{maintenance_id}"
* The usage of custom mapping towards the parser provider had an issue to parse the notification

I'm aware of the lack of test for this second point that has been tested manually, but I plan to refactor the `source` and `handler` code with the new `parser` library and I will add this test then (will create an issue: #82 ), because the current tests are getting too complex (parallel to the code)
