### PR TITLE
New parser library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v0.1.11
 
+### Added
+
+- #86: Adopt new `circuit-maintenance-parser` to simplify email related code. Use `stamp` from notification to define the date of the `RawNotification`. Limit the size of the store `RawNotification` via configuration file.
+
 ### Fixed
 
 - #76: Fix IMAP authentication logic that was not cleaning session after authentication failure.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ PLUGINS = ["nautobot_circuit_maintenance"]
 ```py
 PLUGINS_CONFIG = {
     "nautobot_circuit_maintenance": {
-        "raw_notifications": {"initial_days_since": 100},
+        "raw_notifications": {
+            "initial_days_since": 100,
+            "raw_notification_size": 500,
+        },
         "notification_sources": [
             {
               ...
@@ -44,8 +47,8 @@ In the `raw_notifications` section, you can define:
 
 - `initial_days_since`: define how many days back the plugin will check for `RawNotification`s for each
   `NotificationSource`, in order to limit the number of notifications to be processed on the first run of the plugin.
-  In subsequent runs, the last notification date will be used as the reference to limit. If not defined, it defaults to
-  **365 days**.
+  In subsequent runs, the last notification date will be used as the reference to limit. If not defined, it defaults to **365 days**.
+- `raw_notification_size`: define how many bytes from a notification will be stored in the database to not store too big objects. If not defined, it defaults to **1000** bytes.
 
 The `notification_sources` have custom definition depending on the `Source` type, and are defined in the [Usage](#Usage) section.
 

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -241,26 +241,28 @@ PLUGINS = ["nautobot_circuit_maintenance"]
 # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
 PLUGINS_CONFIG = {
     "nautobot_circuit_maintenance": {
-        "raw_notifications": {"initial_days_since": 100},
+        "raw_notifications": {"initial_days_since": 500},
         "notification_sources": [
             {
                 "name": "my imap source",
                 "account": os.environ.get("CM_NS_1_ACCOUNT", ""),
                 "secret": os.environ.get("CM_NS_1_SECRET", ""),
                 "url": os.environ.get("CM_NS_1_URL", ""),
-                "attach_all_providers": True,
+                # "attach_all_providers": True,
             },
             {
                 "name": "my gmail service account api source",
                 "url": os.environ.get("CM_NS_2_URL", ""),
                 "account": os.environ.get("CM_NS_2_ACCOUNT", ""),
                 "credentials_file": os.environ.get("CM_NS_2_CREDENTIALS_FILE", ""),
+                "attach_all_providers": True,
             },
             {
                 "name": "my gmail oauth api source",
                 "url": os.environ.get("CM_NS_3_URL", ""),
                 "account": os.environ.get("CM_NS_3_ACCOUNT", ""),
                 "credentials_file": os.environ.get("CM_NS_3_CREDENTIALS_FILE", ""),
+                # "attach_all_providers": True,
             },
         ],
         "metrics": {

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -88,12 +88,12 @@ def update_circuit_maintenance(
 
     circuit_entries = CircuitImpact.objects.filter(maintenance=circuit_maintenance_entry)
 
-    parsed_cids = {parsed_circuit.circuit_id for parsed_circuit in parser_maintenance.circuits}
+    new_cids = {parsed_circuit.circuit_id for parsed_circuit in parser_maintenance.circuits}
     existing_cids = {circuit_entry.circuit.cid for circuit_entry in circuit_entries}
 
-    cids_to_update = parsed_cids & existing_cids
-    cids_to_create = parsed_cids - existing_cids
-    cids_to_remove = existing_cids - parsed_cids
+    cids_to_update = new_cids & existing_cids
+    cids_to_create = new_cids - existing_cids
+    cids_to_remove = existing_cids - new_cids
 
     for cid in cids_to_create:
         circuit_entry = Circuit.objects.filter(cid=cid, provider=provider.pk).last()

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -318,7 +318,7 @@ class HandleCircuitMaintenanceNotifications(Job):
             )
         except Exception as error:
             self.log_failure(
-                message=f"Unexpected exception when retrieveing notifications from sources ({notification_sources}): {error}"
+                message=f"Unexpected exception when retrieving notifications from sources ({notification_sources}): {error}"
             )
             return []
 

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -250,8 +250,9 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
             circuit_maintenance_entry = create_or_update_circuit_maintenance(
                 logger, parser_maintenance, raw_entry, provider
             )
-            # Update raw notification as properly parsed
+            # Update raw notification as properly parsed and with the stamp time
             raw_entry.parsed = True
+            raw_entry.date = datetime.datetime.fromtimestamp(parser_maintenance.stamp)
             raw_entry.save()
 
             # Insert parsed notification in DB
@@ -260,7 +261,7 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
                 raw_notification=raw_entry,
                 json=parser_maintenance.to_json(),
             )
-            logger.log_success(parsed_entry, message=f"Saved Parsed Notification for {circuit_maintenance_entry.id}.")
+            logger.log_success(parsed_entry, message=f"Saved Parsed Notification for {circuit_maintenance_entry.name}.")
 
         except Exception as exc:
             tb_str = traceback.format_exception(etype=type(exc), value=exc, tb=exc.__traceback__)

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -27,13 +27,14 @@ def create_circuit_maintenance(
     logger: Job, maintenance_id: str, parser_maintenance, provider: Provider
 ) -> CircuitMaintenance:
     """Handles the creation of a new circuit maintenance."""
-    circuit_maintenance_entry = CircuitMaintenance.objects.create(
+    circuit_maintenance_entry = CircuitMaintenance(
         name=maintenance_id,
         start_time=datetime.datetime.fromtimestamp(parser_maintenance.start),
         end_time=datetime.datetime.fromtimestamp(parser_maintenance.end),
         description=parser_maintenance.summary,
         status=parser_maintenance.status,
     )
+    circuit_maintenance_entry.save()
     logger.log_success(obj=circuit_maintenance_entry, message="Created Circuit Maintenance.")
 
     for circuit in parser_maintenance.circuits:

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -1,7 +1,8 @@
 """Notifications jobs."""
 import datetime
 import traceback
-from typing import Optional
+from typing import Optional, List
+import uuid
 from django.conf import settings
 from circuit_maintenance_parser import ProviderError, init_provider, init_data_email
 from nautobot.circuits.models import Circuit, Provider
@@ -23,19 +24,19 @@ MAX_INITIAL_DAYS_SINCE = 365
 
 
 def create_circuit_maintenance(
-    logger: Job, maintenance_id: str, parsed_notification: ParsedNotification, provider: Provider
+    logger: Job, maintenance_id: str, parser_maintenance, provider: Provider
 ) -> CircuitMaintenance:
     """Handles the creation of a new circuit maintenance."""
     circuit_maintenance_entry = CircuitMaintenance.objects.create(
         name=maintenance_id,
-        start_time=datetime.datetime.fromtimestamp(parsed_notification.start),
-        end_time=datetime.datetime.fromtimestamp(parsed_notification.end),
-        description=parsed_notification.summary,
-        status=parsed_notification.status,
+        start_time=datetime.datetime.fromtimestamp(parser_maintenance.start),
+        end_time=datetime.datetime.fromtimestamp(parser_maintenance.end),
+        description=parser_maintenance.summary,
+        status=parser_maintenance.status,
     )
     logger.log_success(obj=circuit_maintenance_entry, message="Created Circuit Maintenance.")
 
-    for circuit in parsed_notification.circuits:
+    for circuit in parser_maintenance.circuits:
         circuit_entry = Circuit.objects.filter(cid=circuit.circuit_id, provider=provider).last()
         if circuit_entry:
             circuit_impact_entry = CircuitImpact.objects.create(
@@ -65,7 +66,7 @@ def create_circuit_maintenance(
                 ),
             )
     if not CircuitImpact.objects.filter(maintenance=circuit_maintenance_entry):
-        logger.log_warning(message=f"Circuit Maintenance {maintenance_id} has no valid Circuit IDs")
+        logger.log_warning(message=f"Circuit Maintenance {maintenance_id} has none Circuit IDs in the DB.")
 
     return circuit_maintenance_entry
 
@@ -74,20 +75,20 @@ def update_circuit_maintenance(
     logger: Job,
     circuit_maintenance_entry: CircuitMaintenance,
     maintenance_id: str,
-    parsed_notification: ParsedNotification,
+    parser_maintenance,
     provider: Provider,
 ):  # pylint: disable=too-many-locals
     """Handles the update of an existent circuit maintenance."""
-    circuit_maintenance_entry.description = parsed_notification.summary
-    circuit_maintenance_entry.status = parsed_notification.status
-    circuit_maintenance_entry.start_time = datetime.datetime.fromtimestamp(parsed_notification.start)
-    circuit_maintenance_entry.end_time = datetime.datetime.fromtimestamp(parsed_notification.end)
+    circuit_maintenance_entry.description = parser_maintenance.summary
+    circuit_maintenance_entry.status = parser_maintenance.status
+    circuit_maintenance_entry.start_time = datetime.datetime.fromtimestamp(parser_maintenance.start)
+    circuit_maintenance_entry.end_time = datetime.datetime.fromtimestamp(parser_maintenance.end)
     circuit_maintenance_entry.ack = False
     circuit_maintenance_entry.save()
 
     circuit_entries = CircuitImpact.objects.filter(maintenance=circuit_maintenance_entry)
 
-    parsed_cids = {parsed_circuit.circuit_id for parsed_circuit in parsed_notification.circuits}
+    parsed_cids = {parsed_circuit.circuit_id for parsed_circuit in parser_maintenance.circuits}
     existing_cids = {circuit_entry.circuit.cid for circuit_entry in circuit_entries}
 
     cids_to_update = parsed_cids & existing_cids
@@ -97,7 +98,7 @@ def update_circuit_maintenance(
     for cid in cids_to_create:
         circuit_entry = Circuit.objects.filter(cid=cid, provider=provider.pk).last()
         circuit = [
-            parsed_circuit for parsed_circuit in parsed_notification.circuits if parsed_circuit.circuit_id == cid
+            parsed_circuit for parsed_circuit in parser_maintenance.circuits if parsed_circuit.circuit_id == cid
         ][0]
         if circuit_entry:
             circuit_impact_entry = CircuitImpact.objects.create(
@@ -134,7 +135,7 @@ def update_circuit_maintenance(
             circuit=circuit_entry, maintenance=circuit_maintenance_entry
         ).last()
         circuit = [
-            parsed_circuit for parsed_circuit in parsed_notification.circuits if parsed_circuit.circuit_id == cid
+            parsed_circuit for parsed_circuit in parser_maintenance.circuits if parsed_circuit.circuit_id == cid
         ][0]
         circuitimpact_entry.impact = circuit.impact
         circuitimpact_entry.save()
@@ -146,25 +147,23 @@ def update_circuit_maintenance(
     logger.log_info(obj=circuit_maintenance_entry, message=f"Updated Circuit Maintenance {maintenance_id}")
 
 
-def process_parsed_notification(
-    logger: Job, parsed_notification: ParsedNotification, raw_entry: RawNotification, provider: Provider
-):
-    """Processes a Parsed Notification, creating or updating the related Circuit Maintenance."""
-    maintenance_id = f"{raw_entry.provider.slug}-{parsed_notification.maintenance_id}"
+# TODO: Maintenance typing is not exposed in the parser library
+def create_or_update_circuit_maintenance(
+    logger: Job, parser_maintenance, raw_entry: RawNotification, provider: Provider
+) -> CircuitMaintenance:
+    """Processes a Maintenance, creating or updating the related Circuit Maintenance.
+
+    It returns the CircuitMaintenance entry created or updated.
+    """
+    maintenance_id = f"{raw_entry.provider.slug}-{parser_maintenance.maintenance_id}"
     circuit_maintenance_entry = CircuitMaintenance.objects.filter(name=maintenance_id).last()
 
     if circuit_maintenance_entry:
-        update_circuit_maintenance(logger, circuit_maintenance_entry, maintenance_id, parsed_notification, provider)
+        update_circuit_maintenance(logger, circuit_maintenance_entry, maintenance_id, parser_maintenance, provider)
     else:
-        circuit_maintenance_entry = create_circuit_maintenance(logger, maintenance_id, parsed_notification, provider)
+        circuit_maintenance_entry = create_circuit_maintenance(logger, maintenance_id, parser_maintenance, provider)
 
-    # Insert parsed notification in DB
-    parsed_entry = ParsedNotification.objects.create(
-        maintenance=circuit_maintenance_entry,
-        raw_notification=raw_entry,
-        json=parsed_notification.to_json(),
-    )
-    logger.log_success(parsed_entry, message=f"Saved Parsed Notification for {maintenance_id}.")
+    return circuit_maintenance_entry
 
 
 def get_maintenances_from_notification(logger: Job, notification: MaintenanceNotification, provider: Provider):
@@ -186,13 +185,12 @@ def get_maintenances_from_notification(logger: Job, notification: MaintenanceNot
     except ProviderError:
         tb_str = traceback.format_exc()
         logger.log_failure(message=f"Parsing failed for notification `{notification.subject}`:\n```\n{tb_str}\n```")
-        return None
     except Exception:
         tb_str = traceback.format_exc()
         logger.log_failure(
             message=f"Unexpected exception while parsing notification `{notification.subject}`.\n```\n{tb_str}\n```"
         )
-        return None
+    return None
 
 
 def create_raw_notification(logger: Job, notification: MaintenanceNotification, provider: Provider):
@@ -224,10 +222,11 @@ def create_raw_notification(logger: Job, notification: MaintenanceNotification, 
     return raw_entry
 
 
-def process_raw_notification(logger: Job, notification: MaintenanceNotification) -> Optional[int]:
+def process_raw_notification(logger: Job, notification: MaintenanceNotification) -> Optional[uuid.UUID]:
     """Processes a raw notification (maybe containing multiple parsed notifications).
 
-    It creates a RawNotification and if it could be parsed, create the corresponding ParsedNotification.
+    It creates a RawNotification and if it could be parsed, create the corresponding ParsedNotification and the
+    related objects. Finally returns the the UUID of the RawNotification modified.
     """
     provider = Provider.objects.filter(slug=notification.provider_type).last()
     if not provider:
@@ -242,24 +241,50 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
     if not raw_entry:
         return None
 
-    parsed_notifications = get_maintenances_from_notification(logger, notification, provider)
-    if not parsed_notifications:
+    parser_maintenances = get_maintenances_from_notification(logger, notification, provider)
+    if not parser_maintenances:
         return raw_entry.id
 
-    for parsed_notification in parsed_notifications:
+    for parser_maintenance in parser_maintenances:
         try:
-            process_parsed_notification(logger, parsed_notification, raw_entry, provider)
+            circuit_maintenance_entry = create_or_update_circuit_maintenance(
+                logger, parser_maintenance, raw_entry, provider
+            )
             # Update raw notification as properly parsed
             raw_entry.parsed = True
             raw_entry.save()
+
+            # Insert parsed notification in DB
+            parsed_entry = ParsedNotification.objects.create(
+                maintenance=circuit_maintenance_entry,
+                raw_notification=raw_entry,
+                json=parser_maintenance.to_json(),
+            )
+            logger.log_success(parsed_entry, message=f"Saved Parsed Notification for {circuit_maintenance_entry.id}.")
+
         except Exception as exc:
             tb_str = traceback.format_exception(etype=type(exc), value=exc, tb=exc.__traceback__)
-            logger.log_warning(
-                parsed_notification,
+            logger.log_failure(
+                parser_maintenance,
                 message=f"Unexpected exception while handling parsed notification {notification.subject}.\n{tb_str}",
             )
 
     return raw_entry.id
+
+
+def get_since_reference(logger: Job) -> int:
+    """Get the timestamp from the latest processed RawNotification or a reference from config `initial_days_since`."""
+    # Latest retrieved notification will limit the scope of notifications to retrieve
+    last_raw_notification = RawNotification.objects.last()
+    if last_raw_notification:
+        since_reference = last_raw_notification.date.timestamp()
+    else:
+        since_reference = datetime.datetime.utcnow() - datetime.timedelta(
+            days=PLUGIN_SETTINGS.get("raw_notifications", {}).get("initial_days_since", MAX_INITIAL_DAYS_SINCE)
+        )
+        since_reference = int(since_reference.timestamp())
+    logger.log_info(message=f"Processing notifications since {since_reference}")
+    return since_reference
 
 
 class HandleCircuitMaintenanceNotifications(Job):
@@ -271,50 +296,45 @@ class HandleCircuitMaintenanceNotifications(Job):
         """Meta object boilerplate for HandleParsedNotifications."""
 
         name = "Update Circuit Maintenances"
-        description = (
-            "Fetch Circuit Maintenance Notifications from Source and create or update Circuit Maintenances accordingly"
-        )
+        description = "Fetch Circuit Maintenance Notifications from Sources and create or update Circuit Maintenances accordingly."
 
-    def run(self, data=None, commit=None):
+    def run(self, data=None, commit=None) -> List[uuid.UUID]:
         """Fetch notifications, process them and update Circuit Maintenance accordingly."""
         if self.debug is True:
             self.log_debug("Starting Handle Notifications job.")
-        raw_notification_ids = []
+
         notification_sources = NotificationSource.objects.all()
         if not notification_sources:
             self.log_warning(message="No notification sources configured to retrieve notifications from.")
-            return raw_notification_ids
-
-        # Latest retrieved notification will limit the scope of notifications to retrieve
-        last_raw_notification = RawNotification.objects.last()
-        if last_raw_notification:
-            since_reference = last_raw_notification.date.timestamp()
-        else:
-            since_reference = datetime.datetime.utcnow() - datetime.timedelta(
-                days=PLUGIN_SETTINGS.get("raw_notifications", {}).get("initial_days_since", MAX_INITIAL_DAYS_SINCE)
-            )
-            since_reference = int(since_reference.timestamp())
-
-        self.log_info(message=f"Processing notifications since {since_reference}")
+            return []
 
         try:
             notifications = get_notifications(
                 job_logger=self,
                 notification_sources=notification_sources,
-                since=since_reference,
+                since=get_since_reference(self),
             )
-            if not notifications:
-                self.log_info(message="No notifications received.")
-                return raw_notification_ids
+        except Exception as error:
+            self.log_failure(
+                message=f"Unexpected exception when retrieveing notifications from sources ({notification_sources}): {error}"
+            )
+            return []
 
-            for notification in notifications:
-                self.log_info(message=f"Processing notification `{notification.subject}`.")
+        if not notifications:
+            self.log_info(message="No notifications received.")
+            return []
+
+        raw_notification_ids = []
+        for notification in notifications:
+            self.log_info(message=f"Processing notification `{notification.subject}`.")
+            try:
                 raw_id = process_raw_notification(self, notification)
                 if raw_id:
                     raw_notification_ids.append(raw_id)
+            except Exception as error:
+                self.log_failure(message=f"Unexpected exception when parsing notifications: {error}")
 
-        except Exception as error:
-            self.log_failure(message=f"Unexpected exception in Handle Notifications Job: {error}")
         if self.debug is True:
             self.log_debug(f"{len(raw_notification_ids)} notifications processed.")
+
         return raw_notification_ids

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -22,7 +22,6 @@ from django.utils.text import slugify
 
 from pydantic import BaseModel  # pylint: disable=no-name-in-module
 from pydantic.error_wrappers import ValidationError  # pylint: disable=no-name-in-module
-from circuit_maintenance_parser import NonexistentParserError, get_provider_data_types
 from nautobot.circuits.models import Provider
 from nautobot.extras.jobs import Job
 
@@ -43,7 +42,7 @@ class MaintenanceNotification(BaseModel):
     sender: str
     subject: str
     provider_type: str
-    raw_payloads: Iterable[bytes]
+    raw_payload: bytes
 
 
 class Source(BaseModel):
@@ -65,8 +64,8 @@ class Source(BaseModel):
         * source: self.name
         * sender: it could be the email 'from' or omitted if not relevant
         * subject: it could be the email 'subject' or some meaningful identifier from notification
+        * provider_type: mapping to the Provider that is related to this notification
         * raw: the raw_payload from notification
-        * provider_type: the provider slug identified by sender email or from membership
         """
         # TODO: `senders` is used to limit the scope of emails retrieved, this won't have sense depending on the
         # Notification Source.
@@ -247,44 +246,16 @@ class EmailSource(Source):  # pylint: disable=abstract-method
         return email_source.lower()
 
     @staticmethod
-    def extract_provider_data_types(email_source: str) -> Tuple[str, str, str]:
-        """Method to extract the provider data type based on the referenced email for the provider.
-
-        Returns:
-            Tuple(
-                Iterable[str]: provider_data_types, data types related to a specific Provider Parser
-                str: provider_type, corresponding to the Provider slug
-                str: error_message, if there was an issue
-            )
-        """
-        email_source = email_source.lower()
+    def get_provider_type_from_email(email_source: str) -> str:
+        """Return the `Provider` type related to the source."""
         for provider in Provider.objects.all():
             emails_for_provider = provider.cf.get("emails_circuit_maintenances")
             if not emails_for_provider:
                 continue
             sources = [src.strip().lower() for src in emails_for_provider.split(",")]
             if email_source in sources:
-                provider_type = provider.slug
-                # If there is no custom provider mapping defined, we take the provider slug as default mapping
-                provider_parser_circuit_maintenances = provider.cf.get("provider_parser_circuit_maintenances")
-                if provider_parser_circuit_maintenances:
-                    provider_mapping = provider_parser_circuit_maintenances.lower()
-                else:
-                    provider_mapping = provider_type
-                break
-        else:
-            return "", "", f"Sender email {email_source} is not registered for any circuit provider."
-
-        try:
-            provider_data_types = get_provider_data_types(provider_mapping)
-        except NonexistentParserError:
-            return (
-                "",
-                "",
-                f"{email_source} is for provider type `{provider_type}`, which is not presently supported",
-            )
-
-        return provider_data_types, provider_type, ""
+                return provider.slug
+        return ""
 
 
 class IMAP(EmailSource):
@@ -333,12 +304,6 @@ class IMAP(EmailSource):
         raw_email_string = data[0][1].decode("utf-8")
         email_message = email.message_from_string(raw_email_string)
 
-        return self.process_email(job_logger, email_message)
-
-    def process_email(
-        self, job_logger: Job, email_message: email.message.EmailMessage
-    ) -> Optional[MaintenanceNotification]:
-        """Helper method for the fetch_email() method."""
         email_source = self.extract_email_source(email_message[self.source_header])
         if not email_source:
             job_logger.log_warning(
@@ -347,35 +312,12 @@ class IMAP(EmailSource):
             )
             return None
 
-        provider_data_types, provider_type, error_message = self.extract_provider_data_types(email_source)
-        if not provider_data_types:
-            job_logger.log_warning(message=error_message)
-            return None
-
-        raw_payloads = []
-        for provider_data_type in provider_data_types:
-            for part in email_message.walk():
-                if part.get_content_type() == provider_data_type:
-                    raw_payloads.append(part.get_payload())
-                    break
-            else:
-                if job_logger.debug is True:
-                    job_logger.log_debug(
-                        message=f"Payload type {provider_data_type} not found in email payload.",
-                    )
-
-        if not raw_payloads:
-            job_logger.log_warning(
-                message=f"Payload types {', '.join(provider_data_types)} not found in email payload.",
-            )
-            return None
-
         return MaintenanceNotification(
             source=self.name,
-            sender=email_message[self.source_header],
+            sender=email_source,
             subject=email_message["Subject"],
-            raw_payloads=raw_payloads,
-            provider_type=provider_type,
+            provider_type=self.get_provider_type_from_email(email_source),
+            raw_payload=raw_email_string,
         )
 
     def receive_notifications(
@@ -492,67 +434,29 @@ class GmailAPI(EmailSource):
         See data format:  https://developers.google.com/gmail/api/reference/rest/v1/users.messages#Message
         """
         received_email = (
-            self.service.users().messages().get(userId=self.account, id=msg_id).execute()  # pylint: disable=no-member
+            self.service.users()  # pylint: disable=no-member
+            .messages()
+            .get(userId=self.account, id=msg_id, format="raw")
+            .execute()
         )
 
-        return self.process_email(job_logger, received_email, msg_id)
+        raw_email_string = base64.urlsafe_b64decode(received_email["raw"].encode("utf8"))
+        email_message = email.message_from_bytes(raw_email_string)
+        email_source = self.extract_email_source(email_message[self.source_header])
 
-    def process_email(  # pylint: disable=too-many-locals
-        self, job_logger: Job, received_email: Dict, msg_id: bytes
-    ) -> Optional[MaintenanceNotification]:
-        """Helper method for the fetch_email() method."""
-        email_subject = ""
-        email_source = ""
-
-        for header in received_email["payload"]["headers"]:
-            if header.get("name") == "Subject":
-                email_subject = header["value"]
-            elif header.get("name") == self.source_header:
-                email_source = header["value"]
-
-        email_source_before = email_source
-        email_source = self.extract_email_source(email_source)
         if not email_source:
-            job_logger.log_warning(message=f'Not possible to determine the email sender from "{email_source_before}"')
-            return None
-
-        provider_data_types, provider_type, error_message = self.extract_provider_data_types(email_source)
-        if not provider_data_types:
-            job_logger.log_warning(message=error_message)
-            return None
-
-        def get_raw_payload_from_parts(parts, provider_data_type):
-            """Helper function to extract the raw_payload from a multiple parts via a recursive call."""
-            for part_inner in parts:
-                for header_inner in part_inner["headers"]:
-                    if header_inner.get("name") == "Content-Type" and provider_data_type in header_inner.get("value"):
-                        return self.extract_raw_payload(part_inner["body"], msg_id)
-                    if header_inner.get("name") == "Content-Type" and "multipart" in header_inner.get("value"):
-                        return get_raw_payload_from_parts(part_inner["parts"], provider_data_type)
-            return None
-
-        raw_payloads = []
-        for provider_data_type in provider_data_types:
-            if "parts" not in received_email["payload"]:
-                raw_payload = self.extract_raw_payload(received_email["payload"]["body"], msg_id)
-            else:
-                raw_payload = get_raw_payload_from_parts(received_email["payload"]["parts"], provider_data_type)
-            if raw_payload:
-                raw_payloads.append(raw_payload)
-
-        if not raw_payloads:
             job_logger.log_warning(
-                message=f"Payload types {provider_data_types} not found in email payload.",
+                message="Not possible to determine the email sender from "
+                f'"{self.source_header}: {email_message[self.source_header]}"'
             )
             return None
-        if job_logger.debug is True:
-            job_logger.log_debug(message=f"Got notification from {email_source} with subject {email_subject}")
+
         return MaintenanceNotification(
             source=self.name,
             sender=email_source,
-            subject=email_subject,
-            raw_payloads=raw_payloads,
-            provider_type=provider_type,
+            subject=email_message["Subject"],
+            provider_type=self.get_provider_type_from_email(email_source),
+            raw_payload=raw_email_string,
         )
 
     def receive_notifications(

--- a/nautobot_circuit_maintenance/models.py
+++ b/nautobot_circuit_maintenance/models.py
@@ -16,7 +16,7 @@ from nautobot.core.models.generics import PrimaryModel, OrganizationalModel
 from .choices import CircuitImpactChoices, CircuitMaintenanceStatusChoices, NoteLevelChoices
 
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG.get("nautobot_circuit_maintenance", {})
-MAX_RAW_NOTIFICATION_SIZE = 1000
+DEFAULT_RAW_NOTIFICATION_SIZE = 1000
 
 
 @extras_features(
@@ -252,7 +252,7 @@ class RawNotification(OrganizationalModel):
         self._raw_md5 = hashlib.md5(self.raw).hexdigest()  # nosec
         # Limiting the size of the notification stored.
         self.raw = self.raw[
-            : PLUGIN_SETTINGS.get("raw_notifications", {}).get("raw_notification_size", MAX_RAW_NOTIFICATION_SIZE)
+            : PLUGIN_SETTINGS.get("raw_notifications", {}).get("raw_notification_size", DEFAULT_RAW_NOTIFICATION_SIZE)
         ]
         super().save(*args, **kwargs)
 

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -1,10 +1,12 @@
 """Tests for Handle Notifications methods."""
 from unittest.mock import Mock, patch
+from email.message import EmailMessage
+from email.utils import formatdate
 from django.test import TestCase
 from jinja2 import Template
 
 from nautobot.circuits.models import Circuit, Provider
-from circuit_maintenance_parser import init_provider
+from circuit_maintenance_parser import init_provider, init_data_email
 
 from nautobot_circuit_maintenance.handle_notifications.handler import (
     HandleCircuitMaintenanceNotifications,
@@ -24,8 +26,8 @@ from nautobot_circuit_maintenance.models import (
 from nautobot_circuit_maintenance.handle_notifications.sources import MaintenanceNotification
 
 
-def generate_raw_notification(notification_data, source):
-    """Generate raw notification text for a provider."""
+def generate_email_notification(notification_data, source):
+    """Generate email notification text for a provider."""
     raw_notification_template = """
 BEGIN:VCALENDAR
 PRODID:Data::ICal 0.16
@@ -51,12 +53,18 @@ END:VCALENDAR
 """
 
     template = Template(raw_notification_template)
+    email_message = EmailMessage()
+    email_message["From"] = "Sender <sender@example.com>"
+    email_message["Date"] = formatdate()
+    email_message["Subject"] = "Test subject"
+    email_message["Content-Type"] = "text/calendar"
+    email_message.set_payload(template.render(obj=notification_data).encode("utf-8"))
 
     return MaintenanceNotification(
         subject="Test subject",
         sender="sender@example.com",
         source=source,
-        raw_payloads=[template.render(obj=notification_data).encode("utf-8")],
+        raw_payload=email_message.as_bytes(),
         provider_type=notification_data["provider"],
     )
 
@@ -99,7 +107,7 @@ class TestHandleNotificationsJob(TestCase):
     def test_run_simple(self):
         """Test the simple execution to create a Circuit Maintenance."""
         notification_data = get_base_notification_data()
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
 
         with patch(
             "nautobot_circuit_maintenance.handle_notifications.handler.get_notifications"
@@ -121,7 +129,7 @@ class TestHandleNotificationsJob(TestCase):
         notification_data = get_base_notification_data()
         fake_cid = "nonexistent circuit"
         notification_data["circuitimpacts"].append({"cid": fake_cid, "impact": "NO-IMPACT"})
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
 
         with patch(
             "nautobot_circuit_maintenance.handle_notifications.handler.get_notifications"
@@ -172,7 +180,7 @@ class TestHandleNotificationsJob(TestCase):
 
         notification_data = get_base_notification_data()
         notification_data["status"] = "Non valid status"
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
 
         with patch(
             "nautobot_circuit_maintenance.handle_notifications.handler.get_notifications"
@@ -193,10 +201,10 @@ class TestHandleNotificationsJob(TestCase):
     def test_process_raw_notification_no_provider_in_parser(self):
         """Test process_raw_notification with non existant Proivder in the parser library."""
         notification_data = get_base_notification_data()
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
         test_notification.provider_type = "abc"
         res = process_raw_notification(self.job, test_notification)
-        self.assertEqual(res, None)
+        self.assertNotEqual(res, None)
         self.job.log_warning.assert_called_with(
             message=f"Notification Parser not found for {test_notification.provider_type}"
         )
@@ -204,7 +212,7 @@ class TestHandleNotificationsJob(TestCase):
     def test_process_raw_notification_no_provider_in_plugin(self):
         """Test process_raw_notification with non existant provider in the Plugin."""
         notification_data = get_base_notification_data()
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
         test_notification.provider_type = "telstra"
         res = process_raw_notification(self.job, test_notification)
         self.assertEqual(res, None)
@@ -215,7 +223,7 @@ class TestHandleNotificationsJob(TestCase):
     def test_process_raw_notification(self):
         """Test process_raw_notification."""
         notification_data = get_base_notification_data()
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
         res = process_raw_notification(self.job, test_notification)
 
         raw_notification = RawNotification.objects.get(pk=res)
@@ -228,7 +236,7 @@ class TestHandleNotificationsJob(TestCase):
         """Test process_raw_notification with parsing issues"""
         notification_data = get_base_notification_data()
         notification_data["status"] = "Non valid status"
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
         res = process_raw_notification(self.job, test_notification)
 
         raw_notification = RawNotification.objects.get(pk=res)
@@ -241,48 +249,48 @@ class TestHandleNotificationsJob(TestCase):
     def test_create_circuit_maintenance(self):
         """Test create_circuit_maintenance."""
         notification_data = get_base_notification_data()
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
         provider = Provider.objects.get(slug=test_notification.provider_type)
-        for raw_payload in test_notification.raw_payloads:
-            parser = init_provider(provider_type=test_notification.provider_type, raw=raw_payload)
-            raw_entry, _ = RawNotification.objects.get_or_create(
-                subject=test_notification.subject,
-                provider=provider,
-                raw=raw_payload,
-                sender=test_notification.sender,
-                source=self.source,
-            )
-            parsed_maintenance = parser.process()[0]
-            create_circuit_maintenance(self.job, raw_entry.id, parsed_maintenance, provider)
-            self.assertEqual(1, len(CircuitMaintenance.objects.all()))
-            self.assertEqual(2, len(CircuitImpact.objects.all()))
-            self.assertEqual(0, len(Note.objects.all()))
+        raw_entry, _ = RawNotification.objects.get_or_create(
+            subject=test_notification.subject,
+            provider=provider,
+            raw=test_notification.raw_payload,
+            sender=test_notification.sender,
+            source=self.source,
+        )
+        parser_provider = init_provider(provider_type=test_notification.provider_type)
+        data_to_process = init_data_email(test_notification.raw_payload)
+        parsed_maintenance = parser_provider.get_maintenances(data_to_process)[0]
+        create_circuit_maintenance(self.job, raw_entry.id, parsed_maintenance, provider)
+        self.assertEqual(1, len(CircuitMaintenance.objects.all()))
+        self.assertEqual(2, len(CircuitImpact.objects.all()))
+        self.assertEqual(0, len(Note.objects.all()))
 
     def test_create_circuit_maintenance_no_circuits(self):
         """Test create_circuit_maintenance without existent circuits."""
         notification_data = get_base_notification_data()
         notification_data["circuitimpacts"] = [{"cid": "nonexistent", "impact": "NO-IMPACT"}]
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
         provider = Provider.objects.get(slug=test_notification.provider_type)
-        for raw_payload in test_notification.raw_payloads:
-            parser = init_provider(provider_type=test_notification.provider_type, raw=raw_payload)
-            raw_entry, _ = RawNotification.objects.get_or_create(
-                subject=test_notification.subject,
-                provider=provider,
-                raw=raw_payload,
-                sender=test_notification.sender,
-                source=self.source,
-            )
-            parsed_maintenance = parser.process()[0]
-            create_circuit_maintenance(self.job, raw_entry.id, parsed_maintenance, provider)
-            self.assertEqual(1, len(CircuitMaintenance.objects.all()))
-            self.assertEqual(0, len(CircuitImpact.objects.all()))
-            self.assertEqual(1, len(Note.objects.all()))
+        raw_entry, _ = RawNotification.objects.get_or_create(
+            subject=test_notification.subject,
+            provider=provider,
+            raw=test_notification.raw_payload,
+            sender=test_notification.sender,
+            source=self.source,
+        )
+        parser_provider = init_provider(provider_type=test_notification.provider_type)
+        data_to_process = init_data_email(test_notification.raw_payload)
+        parsed_maintenance = parser_provider.get_maintenances(data_to_process)[0]
+        create_circuit_maintenance(self.job, raw_entry.id, parsed_maintenance, provider)
+        self.assertEqual(1, len(CircuitMaintenance.objects.all()))
+        self.assertEqual(0, len(CircuitImpact.objects.all()))
+        self.assertEqual(1, len(Note.objects.all()))
 
     def test_update_circuit_maintenance(self):
         """Test update_circuit_maintenance."""
         notification_data = get_base_notification_data()
-        test_notification = generate_raw_notification(notification_data, self.source.name)
+        test_notification = generate_email_notification(notification_data, self.source.name)
         provider = Provider.objects.get(slug=test_notification.provider_type)
         with patch(
             "nautobot_circuit_maintenance.handle_notifications.handler.get_notifications"
@@ -297,20 +305,17 @@ class TestHandleNotificationsJob(TestCase):
         notification_data["circuitimpacts"].append({"cid": "nonexistent", "impact": "NO-IMPACT"})
         circuit_to_update["impact"] = "OUTAGE"
         notification_data["circuitimpacts"].append(circuit_to_update)
-        test_notification = generate_raw_notification(notification_data, self.source.name)
-        for raw_payload in test_notification.raw_payloads:
-            parser = init_provider(provider_type=test_notification.provider_type, raw=raw_payload)
-
-            parsed_maintenance = parser.process()[0]
-            maintenance_id = f"{provider.slug}-{parsed_maintenance.maintenance_id}"
-            circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
-            update_circuit_maintenance(
-                self.job, circuit_maintenance_entry, maintenance_id, parsed_maintenance, provider
-            )
-            self.assertEqual(1, len(CircuitMaintenance.objects.all()))
-            self.assertEqual(1, len(CircuitImpact.objects.all()))
-            self.assertEqual(1, len(Note.objects.all()))
-            circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
-            self.assertEqual(notification_data["status"], circuit_maintenance_entry.status)
-            circuit_impact_entry = CircuitImpact.objects.get(circuit__cid=circuit_to_update["cid"])
-            self.assertEqual(circuit_to_update["impact"], circuit_impact_entry.impact)
+        test_notification = generate_email_notification(notification_data, self.source.name)
+        parser_provider = init_provider(provider_type=test_notification.provider_type)
+        data_to_process = init_data_email(test_notification.raw_payload)
+        parsed_maintenance = parser_provider.get_maintenances(data_to_process)[0]
+        maintenance_id = f"{provider.slug}-{parsed_maintenance.maintenance_id}"
+        circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
+        update_circuit_maintenance(self.job, circuit_maintenance_entry, maintenance_id, parsed_maintenance, provider)
+        self.assertEqual(1, len(CircuitMaintenance.objects.all()))
+        self.assertEqual(1, len(CircuitImpact.objects.all()))
+        self.assertEqual(1, len(Note.objects.all()))
+        circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
+        self.assertEqual(notification_data["status"], circuit_maintenance_entry.status)
+        circuit_impact_entry = CircuitImpact.objects.get(circuit__cid=circuit_to_update["cid"])
+        self.assertEqual(circuit_to_update["impact"], circuit_impact_entry.impact)

--- a/poetry.lock
+++ b/poetry.lock
@@ -156,7 +156,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "circuit-maintenance-parser"
-version = "1.2.3"
+version = "2.0.0b0"
 description = "Python library to parse Circuit Maintenance notifications and return a structured data back"
 category = "main"
 optional = false
@@ -1674,7 +1674,7 @@ metrics = ["nautobot-capacity-metrics"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "a221545a278d66c7b61d8e6d9c282e6206e8119a634536244f848bce2c327beb"
+content-hash = "5240be473e43670b7f15dfa6e1bfd839a1d540fa2c27d5d49364168e6eda38ec"
 
 [metadata.files]
 aniso8601 = [
@@ -1764,8 +1764,8 @@ chardet = [
     {file = "chardet-4.0.0.tar.gz", hash = "sha256:0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa"},
 ]
 circuit-maintenance-parser = [
-    {file = "circuit-maintenance-parser-1.2.3.tar.gz", hash = "sha256:c92c5ba335698d836dc131545ca343828bd211c064a56163443fc2aabbebbce9"},
-    {file = "circuit_maintenance_parser-1.2.3-py3-none-any.whl", hash = "sha256:ab73554d4be6db89de412a514f2ebe4a6398250fa512ffb6a427f454f88a779b"},
+    {file = "circuit-maintenance-parser-2.0.0b0.tar.gz", hash = "sha256:b632759a6f6a9b64a1648c322ed943cdbb2faa1d05c31fc6ead8aee0bf629463"},
+    {file = "circuit_maintenance_parser-2.0.0b0-py3-none-any.whl", hash = "sha256:cd8c32edd367e036d6f5f115ef89c5b05ce38dbc5fe53fd50a7fa0e6b9db1163"},
 ]
 click = [
     {file = "click-8.0.1-py3-none-any.whl", hash = "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ nautobot-capacity-metrics = {version = "*", optional = true }
 # nautobot = { git = "https://github.com/nautobot/nautobot.git", branch = "develop"}
 bs4 = "^0.0.1"
 pydantic = "^1.8.1"
-circuit-maintenance-parser = "^1.2.3"
+circuit-maintenance-parser = "2.0.0-beta"
 google-api-python-client = "^2.9.0"
 google-oauth = "^1.0.0"
 google-auth-httplib2 = "^0.1.0"


### PR DESCRIPTION
Goal: Use new `circuit-maintenance-parser` library, with new methods to simply client usage and reorg code to simplify and increase test coverage

# Changes

- [x] Adopt the new `circuit-maintenance-parser` init methods, simplifying the logic to send the email data directly to the library. To homogenize the usage, in `GmailSources` we move to the `raw` data. This also allowed the reuse the `process_email` between `EmailSources`. This also removed a lot of logic regarding email manipulation.
- [x] Revisit the logic in `handler.py` to make it more readable and add new related testing. There are some changes on return objects in some functions (for instance, the `process_raw_notification` now creates the `RawNotification` even the provider _type is not supported by the parser library)
- [x] Check `Raw` visualisation and storage for `RawNotification` because now emails are fully dumped
- [x] Use `Stamp` from the parser `Maintenance` to set the `RawNotification.date`

I tried to simplify the logic as much as possible, but any suggestion on it will be more than welcome!