### PR TITLE
Improve `RawNotification` creation, validating Integrity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.3 -
+
+### Fix
+
+- #104: When creating `RawNotification` we validate the `Integrity` exception from the DB to avoid postponing the error and handling it gracefully. Also, the `RawNotification.date` is now taken directly from the email notification `Date` instead of waiting for the parsing output, that will contain the same value in the `stamp` attribute.
+
 ## v0.2.2 - 2021-09-17
 
 ### Fix

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -241,7 +241,7 @@ PLUGINS = ["nautobot_circuit_maintenance"]
 # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
 PLUGINS_CONFIG = {
     "nautobot_circuit_maintenance": {
-        "raw_notifications": {"initial_days_since": 500},
+        "raw_notifications": {"initial_days_since": 365},
         "notification_sources": [
             {
                 "name": "my imap source",
@@ -256,6 +256,7 @@ PLUGINS_CONFIG = {
                 "account": os.environ.get("CM_NS_2_ACCOUNT", ""),
                 "credentials_file": os.environ.get("CM_NS_2_CREDENTIALS_FILE", ""),
                 "attach_all_providers": True,
+                # "source_header": "X-Original-Sender",
             },
             {
                 "name": "my gmail oauth api source",

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -3,7 +3,10 @@ import datetime
 import traceback
 from typing import Optional, List
 import uuid
+from dateutil import parser
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.db import IntegrityError
 from circuit_maintenance_parser import ProviderError, init_provider, NotificationData, Maintenance
 from nautobot.circuits.models import Circuit, Provider
 from nautobot.extras.jobs import Job, BooleanVar
@@ -200,21 +203,22 @@ def create_raw_notification(logger: Job, notification: MaintenanceNotification, 
     """
     # Insert raw notification in DB even failed parsing
     try:
-        raw_entry, created = RawNotification.objects.get_or_create(
+        raw_entry = RawNotification(
             subject=notification.subject,
             provider=provider,
             raw=notification.raw_payload,
             sender=notification.sender,
             source=NotificationSource.objects.filter(name=notification.source).last(),
+            date=parser.parse(notification.date),
         )
-    except Exception as exc:
-        logger.log_warning(message=f"Raw notification '{notification.subject}' not created because {str(exc)}")
-        return None
-
-    if not created:
+        raw_entry.save()
+    except IntegrityError as exc:
         # If the RawNotification was already created, we ignore it.
         if logger.debug:
-            logger.log_debug(message=f"Raw notification '{raw_entry.subject}' already existed with id {raw_entry.pk}")
+            logger.log_debug(message=f"Raw notification already existed: {str(exc)}")
+        return None
+    except Exception as exc:
+        logger.log_warning(message=f"Raw notification '{notification.subject}' not created because {str(exc)}")
         return None
 
     logger.log_success(raw_entry, message="Raw notification created.")
@@ -228,8 +232,9 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
     It creates a RawNotification and if it could be parsed, create the corresponding ParsedNotification and the
     related objects. Finally returns the the UUID of the RawNotification modified.
     """
-    provider = Provider.objects.filter(slug=notification.provider_type).last()
-    if not provider:
+    try:
+        provider = Provider.objects.get(slug=notification.provider_type)
+    except ObjectDoesNotExist:
         logger.log_warning(
             message=(
                 f"Raw notification not created because is referencing to a provider not existent: {notification.provider_type}"
@@ -252,7 +257,6 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
             )
             # Update raw notification as properly parsed and with the stamp time
             raw_entry.parsed = True
-            raw_entry.date = datetime.datetime.fromtimestamp(parser_maintenance.stamp)
             raw_entry.save()
 
             # Insert parsed notification in DB

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -159,11 +159,10 @@ def create_or_update_circuit_maintenance(
     It returns the CircuitMaintenance entry created or updated.
     """
     maintenance_id = f"{raw_entry.provider.slug}-{parser_maintenance.maintenance_id}"
-    circuit_maintenance_entry = CircuitMaintenance.objects.filter(name=maintenance_id).last()
-
-    if circuit_maintenance_entry:
+    try:
+        circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
         update_circuit_maintenance(logger, circuit_maintenance_entry, maintenance_id, parser_maintenance, provider)
-    else:
+    except ObjectDoesNotExist:
         circuit_maintenance_entry = create_circuit_maintenance(logger, maintenance_id, parser_maintenance, provider)
 
     return circuit_maintenance_entry

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -43,6 +43,7 @@ class MaintenanceNotification(BaseModel):
     subject: str
     provider_type: str
     raw_payload: bytes
+    date: str
 
 
 class Source(BaseModel):
@@ -284,6 +285,7 @@ class EmailSource(Source):  # pylint: disable=abstract-method
             subject=email_message["Subject"],
             provider_type=provider_type,
             raw_payload=email_message.as_bytes(),
+            date=email_message["Date"],
         )
 
 

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -67,6 +67,7 @@ END:VCALENDAR
         source=source,
         raw_payload=email_message.as_bytes(),
         provider_type=notification_data["provider"],
+        date="Mon, 1 Feb 2021 09:33:34 +0000",
     )
 
 

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -4,7 +4,6 @@ from email.message import EmailMessage
 from email.utils import formatdate
 from django.test import TestCase
 from jinja2 import Template
-
 from nautobot.circuits.models import Circuit, Provider
 from circuit_maintenance_parser import init_provider, NotificationData
 
@@ -233,6 +232,15 @@ class TestHandleNotificationsJob(TestCase):
         self.assertEqual(raw_notification.parsed, True)
         self.assertEqual(1, len(ParsedNotification.objects.all()))
         self.job.log_success.assert_any_call(raw_notification, message="Raw notification created.")
+
+    def test_process_raw_notification_duplicated_issue(self):
+        """Test process_raw_notification duplicated."""
+        self.test_process_raw_notification()
+        notification_data = get_base_notification_data()
+        test_notification = generate_email_notification(notification_data, self.source.name)
+        res = process_raw_notification(self.job, test_notification)
+        self.assertEqual(res, None)
+        self.assertIn("Raw notification already existed", str(self.job.log_debug.call_args))
 
     def test_process_raw_notification_parser_issue(self):
         """Test process_raw_notification with parsing issues"""

--- a/nautobot_circuit_maintenance/tests/test_sources.py
+++ b/nautobot_circuit_maintenance/tests/test_sources.py
@@ -133,6 +133,7 @@ class TestEmailSource(TestCase):
         email_message = EmailMessage()
         email_message["From"] = "User <user@example.com>"
         email_message["Subject"] = "Circuit Maintenance Notification"
+        email_message["Date"] = "Mon, 1 Feb 2021 09:33:34 +0000"
         email_message["Content-Type"] = "text/html"
         email_message.set_payload(b"Some text goes here")
 
@@ -167,6 +168,7 @@ class TestEmailSource(TestCase):
 
         email_message = EmailMessage()
         email_message["From"] = "Mailing List <mailing-list@example.com>"
+        email_message["Date"] = "Mon, 1 Feb 2021 09:33:34 +0000"
         email_message["X-Original-Sender"] = "User <user@example.com>"
         email_message["Subject"] = "Circuit Maintenance Notification"
         email_message["Content-Type"] = "text/html"


### PR DESCRIPTION
Now, we take care as soon as an `Integrity` issue happens, and don't postpone it until the end of the execution as done with the `get_or_create` approach.
Other small changes:
* The Email Notification comes with the `Date` that is the one used as the `Date` for the `RawNotification` being able to understand if this is a duplicated notification in creation time, not waiting for the `Stamp` that will come from the `ParsedNotification`
* Using the `get` and `ObjectDoesNotExist` paradigm to retrieve elements. I believe it's easier to read.