### PR TITLE
Verify a RawNotification exists before creating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.4
+
+### Fix
+
+- #108: Do not use the `IntegrityError` exception to avoid duplicating entries by verifying that the object exists before creating it.
+
 ## v0.2.3 - 2021-09-17
 
 ### Fix

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -6,7 +6,6 @@ import uuid
 from dateutil import parser
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import IntegrityError
 from circuit_maintenance_parser import ProviderError, init_provider, NotificationData, Maintenance
 from nautobot.circuits.models import Circuit, Provider
 from nautobot.extras.jobs import Job, BooleanVar
@@ -200,27 +199,31 @@ def create_raw_notification(logger: Job, notification: MaintenanceNotification, 
 
     If it already exists, we return `None` to signal we are skipping it.
     """
-    # Insert raw notification in DB even failed parsing
     try:
-        raw_entry = RawNotification(
+        raw_entry = RawNotification.objects.get(
             subject=notification.subject,
             provider=provider,
-            raw=notification.raw_payload,
-            sender=notification.sender,
-            source=NotificationSource.objects.filter(name=notification.source).last(),
             date=parser.parse(notification.date),
         )
-        raw_entry.save()
-    except IntegrityError as exc:
         # If the RawNotification was already created, we ignore it.
         if logger.debug:
-            logger.log_debug(message=f"Raw notification already existed: {str(exc)}")
+            logger.log_debug(message=f"Raw notification already existed with ID: {raw_entry.id}")
         return None
-    except Exception as exc:
-        logger.log_warning(message=f"Raw notification '{notification.subject}' not created because {str(exc)}")
-        return None
-
-    logger.log_success(raw_entry, message="Raw notification created.")
+    except ObjectDoesNotExist:
+        try:
+            raw_entry = RawNotification(
+                subject=notification.subject,
+                provider=provider,
+                raw=notification.raw_payload,
+                sender=notification.sender,
+                source=NotificationSource.objects.filter(name=notification.source).last(),
+                date=parser.parse(notification.date),
+            )
+            raw_entry.save()
+            logger.log_success(raw_entry, message="Raw notification created.")
+        except Exception as exc:
+            logger.log_warning(message=f"Raw notification '{notification.subject}' not created because {str(exc)}")
+            return None
 
     return raw_entry
 

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -222,7 +222,7 @@ def create_raw_notification(logger: Job, notification: MaintenanceNotification, 
             raw_entry.save()
             logger.log_success(raw_entry, message="Raw notification created.")
         except Exception as exc:
-            logger.log_warning(message=f"Raw notification '{notification.subject}' not created because {str(exc)}")
+            logger.log_failure(message=f"Raw notification '{notification.subject}' not created because {str(exc)}")
             return None
 
     return raw_entry

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -238,9 +238,17 @@ class TestHandleNotificationsJob(TestCase):
         self.test_process_raw_notification()
         notification_data = get_base_notification_data()
         test_notification = generate_email_notification(notification_data, self.source.name)
+
+        # A duplicated RawNotification skip creation
         res = process_raw_notification(self.job, test_notification)
         self.assertEqual(res, None)
         self.assertIn("Raw notification already existed with ID", str(self.job.log_debug.call_args))
+
+        # After a duplicated RawNotification, a new RawNotification should be inserted
+        test_notification.subject = "another_subject"
+        res = process_raw_notification(self.job, test_notification)
+        raw_notification = RawNotification.objects.get(pk=res)
+        self.assertEqual(raw_notification.pk, res)
 
     def test_process_raw_notification_parser_issue(self):
         """Test process_raw_notification with parsing issues"""

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -240,7 +240,7 @@ class TestHandleNotificationsJob(TestCase):
         test_notification = generate_email_notification(notification_data, self.source.name)
         res = process_raw_notification(self.job, test_notification)
         self.assertEqual(res, None)
-        self.assertIn("Raw notification already existed", str(self.job.log_debug.call_args))
+        self.assertIn("Raw notification already existed with ID", str(self.job.log_debug.call_args))
 
     def test_process_raw_notification_parser_issue(self):
         """Test process_raw_notification with parsing issues"""


### PR DESCRIPTION
Address #107 

Checking for `IntegrityError` was not good enough to avoid hitting, sporadically, the `atomic block`.
Now the approach uses the `ObjectDoesNotExist` before creating, so not hitting this issue.