### PR TITLE
Add 'source_header_limit_emails' to filter from Gmail API when not using 'From'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.4
+
+### Added
+
+- #109: For Gmail API sources, add a new configuration item `source_header_limit_emails` to be used when the `source_header` is not `From` to limit the number of notifications received from a mailing list or alias.
+
 ## v0.2.3 - 2021-09-17
 
 ### Fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- #109: For Gmail API sources, add a new configuration item `limit_emails_without_header_from` to be used when the `source_header` is not `From` to limit the number of notifications received from a mailing list or alias.
+- #109: For Gmail API sources, add a new configuration item `limit_emails_with_not_header_from` to be used when the `source_header` is not `From` to limit the number of notifications received from a mailing list or alias.
 
 ### Fix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- #109: For Gmail API sources, add a new configuration item `source_header_limit_emails` to be used when the `source_header` is not `From` to limit the number of notifications received from a mailing list or alias.
+- #109: For Gmail API sources, add a new configuration item `limit_emails_without_header_from` to be used when the `source_header` is not `From` to limit the number of notifications received from a mailing list or alias.
 
 ## v0.2.3 - 2021-09-17
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ There are 2 extra required attributes:
 There are also two optional attributes:
 
 - `source_header`: Specify a particular email header to use to identify the source of a particular notification and assign it to the appropriate provider. If unset, `From` will be used, but if your emails are not received directly from the provider but instead pass through a mailing list or alias, you might need to set this to a different value such as `X-Original-Sender` instead.
+- `source_header_limit_emails`: Restrict the emails used as "From", maybe a email from a mailing list or alias, in order to limit the emails that are processed.
 - `extra_scopes`: Specify a list of additional Google OAuth2 scopes to request access to in addition to GMail API access.
 
 ```py
@@ -133,6 +134,7 @@ PLUGINS_CONFIG = {
                 "credentials_file": os.getenv("CM_NS_1_CREDENTIALS_FILE", ""),
                 "url": os.getenv("CM_NS_1_URL", ""),
                 "source_header": os.getenv("CM_NS_1_SOURCE_HEADER", "From"),          # optional
+                "source_header_limit_emails": ["email@example.com"],                  # optional
                 "extra_scopes": ["https://www.googleapis.com/auth/calendar.events"],  # optional
             }
         ]

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ There are 2 extra required attributes:
 There are also two optional attributes:
 
 - `source_header`: Specify a particular email header to use to identify the source of a particular notification and assign it to the appropriate provider. If unset, `From` will be used, but if your emails are not received directly from the provider but instead pass through a mailing list or alias, you might need to set this to a different value such as `X-Original-Sender` instead.
-- `source_header_limit_emails`: Restrict the emails used as "From", maybe a email from a mailing list or alias, in order to limit the emails that are processed.
+- `limit_emails_without_header_from`: Restrict the emails used as "From", maybe a email from a mailing list or alias, in order to limit the emails that are processed.
 - `extra_scopes`: Specify a list of additional Google OAuth2 scopes to request access to in addition to GMail API access.
 
 ```py
@@ -134,7 +134,7 @@ PLUGINS_CONFIG = {
                 "credentials_file": os.getenv("CM_NS_1_CREDENTIALS_FILE", ""),
                 "url": os.getenv("CM_NS_1_URL", ""),
                 "source_header": os.getenv("CM_NS_1_SOURCE_HEADER", "From"),          # optional
-                "source_header_limit_emails": ["email@example.com"],                  # optional
+                "limit_emails_without_header_from": ["email@example.com"],                  # optional
                 "extra_scopes": ["https://www.googleapis.com/auth/calendar.events"],  # optional
             }
         ]

--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ There are 2 extra required attributes:
 - `account`: Identifier (i.e. email address) to access via OAuth or to impersonate as service account.
 - `credentials_file`: JSON file containing all the necessary data to identify the API integration (see below).
 
-There are also two optional attributes:
+There are also three optional attributes:
 
 - `source_header`: Specify a particular email header to use to identify the source of a particular notification and assign it to the appropriate provider. If unset, `From` will be used, but if your emails are not received directly from the provider but instead pass through a mailing list or alias, you might need to set this to a different value such as `X-Original-Sender` instead.
-- `limit_emails_without_header_from`: Restrict the emails used as "From", maybe a email from a mailing list or alias, in order to limit the emails that are processed.
+- `limit_emails_with_not_header_from`: List of emails used to restrict the emails retrieved when NOT using the `source_header` "From" and we can't use the `Provider` original emails to filter.
 - `extra_scopes`: Specify a list of additional Google OAuth2 scopes to request access to in addition to GMail API access.
 
 ```py
@@ -134,7 +134,7 @@ PLUGINS_CONFIG = {
                 "credentials_file": os.getenv("CM_NS_1_CREDENTIALS_FILE", ""),
                 "url": os.getenv("CM_NS_1_URL", ""),
                 "source_header": os.getenv("CM_NS_1_SOURCE_HEADER", "From"),          # optional
-                "limit_emails_without_header_from": ["email@example.com"],                  # optional
+                "limit_emails_with_not_header_from": ["email@example.com"],                  # optional
                 "extra_scopes": ["https://www.googleapis.com/auth/calendar.events"],  # optional
             }
         ]

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -162,7 +162,7 @@ class Source(BaseModel):
                     account=config.get("account"),
                     credentials_file=creds_filename,
                     source_header=config.get("source_header", "From"),
-                    source_header_limit_emails=config.get("source_header_limit_emails", []),
+                    limit_emails_without_header_from=config.get("limit_emails_without_header_from", []),
                     extra_scopes=config.get("extra_scopes", []),
                 )
 
@@ -408,7 +408,7 @@ class GmailAPI(EmailSource):
     SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
     extra_scopes: List[str] = []
-    source_header_limit_emails: List[str] = []
+    limit_emails_without_header_from: List[str] = []
 
     class Config:
         """Pydantic BaseModel config."""
@@ -478,12 +478,12 @@ class GmailAPI(EmailSource):
 
         # If source_header is not "From" but some other custom header such as X-Original-Sender,
         # the GMail API doesn't let us filter by that, but if we provided via config a list of
-        # source via `source_header_limit_emails`, we filter by that.
+        # source via `limit_emails_without_header_from`, we filter by that.
         if self.emails_to_fetch and self.source_header == "From":
             emails_with_from = [f"from:{email}" for email in self.emails_to_fetch]
             search_criteria += " {" + f'{" ".join(emails_with_from)}' + "}"
-        elif self.emails_to_fetch and self.source_header_limit_emails:
-            emails_with_from = [f"from:{email}" for email in self.source_header_limit_emails]
+        elif self.emails_to_fetch and self.limit_emails_without_header_from:
+            emails_with_from = [f"from:{email}" for email in self.limit_emails_without_header_from]
             search_criteria += " {" + f'{" ".join(emails_with_from)}' + "}"
 
         # TODO: For now not covering pagination as a way to limit the number of messages

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -162,7 +162,7 @@ class Source(BaseModel):
                     account=config.get("account"),
                     credentials_file=creds_filename,
                     source_header=config.get("source_header", "From"),
-                    limit_emails_without_header_from=config.get("limit_emails_without_header_from", []),
+                    limit_emails_with_not_header_from=config.get("limit_emails_with_not_header_from", []),
                     extra_scopes=config.get("extra_scopes", []),
                 )
 
@@ -410,7 +410,7 @@ class GmailAPI(EmailSource):
     SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
 
     extra_scopes: List[str] = []
-    limit_emails_without_header_from: List[str] = []
+    limit_emails_with_not_header_from: List[str] = []
 
     class Config:
         """Pydantic BaseModel config."""
@@ -475,12 +475,12 @@ class GmailAPI(EmailSource):
 
         # If source_header is not "From" but some other custom header such as X-Original-Sender,
         # the GMail API doesn't let us filter by that, but if we provided via config a list of
-        # source via `limit_emails_without_header_from`, we filter by that.
+        # source via `limit_emails_with_not_header_from`, we filter by that.
         if self.emails_to_fetch and self.source_header == "From":
             emails_with_from = [f"from:{email}" for email in self.emails_to_fetch]
             search_criteria += " {" + f'{" ".join(emails_with_from)}' + "}"
-        elif self.emails_to_fetch and self.limit_emails_without_header_from:
-            emails_with_from = [f"from:{email}" for email in self.limit_emails_without_header_from]
+        elif self.emails_to_fetch and self.limit_emails_with_not_header_from:
+            emails_with_from = [f"from:{email}" for email in self.limit_emails_with_not_header_from]
             search_criteria += " {" + f'{" ".join(emails_with_from)}' + "}"
 
         return search_criteria

--- a/nautobot_circuit_maintenance/tests/test_sources.py
+++ b/nautobot_circuit_maintenance/tests/test_sources.py
@@ -610,3 +610,53 @@ class TestGmailAPISource(TestCase):
         )
 
         return (provider, job, source)
+
+    @parameterized.expand(
+        [
+            [
+                None,
+                "From",
+                ["email1@example.com", "email2@example.com"],
+                [],
+                " {from:email1@example.com from:email2@example.com}",
+            ],
+            [
+                datetime.datetime(2021, 9, 20, 17, 49, 50, 0),
+                "From",
+                ["email1@example.com", "email2@example.com"],
+                [],
+                "after:2021/09/20 {from:email1@example.com from:email2@example.com}",
+            ],
+            [None, "X-Original-Sender", ["email1@example.com", "email2@example.com"], [], ""],
+            [
+                None,
+                "X-Original-Sender",
+                ["email1@example.com", "email2@example.com"],
+                ["mailinglist1@example.com", "mailinglist2@example.com"],
+                " {from:mailinglist1@example.com from:mailinglist2@example.com}",
+            ],
+            [
+                datetime.datetime(2021, 9, 20, 17, 49, 50, 0),
+                "X-Original-Sender",
+                ["email1@example.com", "email2@example.com"],
+                ["mailinglist1@example.com", "mailinglist2@example.com"],
+                "after:2021/09/20 {from:mailinglist1@example.com from:mailinglist2@example.com}",
+            ],
+        ]  # pylint: disable=too-many-arguments
+    )
+    def test_get_search_criteria(
+        self, since_timestamp, source_header, emails_to_fetch, limit_emails_without_header_from, result
+    ):
+        """Test the get_search_criteria method."""
+        source = GmailAPI(
+            name="whatever",
+            url="https://accounts.google.com/o/oauth2/auth",
+            account="account",
+            credentials_file="path_to_file",
+            source_header=source_header,
+            limit_emails_without_header_from=limit_emails_without_header_from,
+        )
+
+        source.emails_to_fetch = emails_to_fetch
+
+        self.assertEqual(result, source._get_search_criteria(since_timestamp))  # pylint: disable=protected-access

--- a/nautobot_circuit_maintenance/tests/test_sources.py
+++ b/nautobot_circuit_maintenance/tests/test_sources.py
@@ -645,7 +645,7 @@ class TestGmailAPISource(TestCase):
         ]  # pylint: disable=too-many-arguments
     )
     def test_get_search_criteria(
-        self, since_timestamp, source_header, emails_to_fetch, limit_emails_without_header_from, result
+        self, since_timestamp, source_header, emails_to_fetch, limit_emails_with_not_header_from, result
     ):
         """Test the get_search_criteria method."""
         source = GmailAPI(
@@ -654,7 +654,7 @@ class TestGmailAPISource(TestCase):
             account="account",
             credentials_file="path_to_file",
             source_header=source_header,
-            limit_emails_without_header_from=limit_emails_without_header_from,
+            limit_emails_with_not_header_from=limit_emails_with_not_header_from,
         )
 
         source.emails_to_fetch = emails_to_fetch


### PR DESCRIPTION
When using Gmail API, and the `X-Original-Sender` as `source_header`, we are not able to filter emails (#98).
This PR adds a new configuration attribute, for Gmail API configuration, that can be used to limit the notifications processed sent from a mailing list or alias, so omitting emails that has nothing to do with Circuit Maintenance notifications.