### PR TITLE
Use the rawnotification date, instead of the parsed notification date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.5
+
+### Fix
+
+- #113: In `CircuitMaintenace` detail view, when the parsed notifications are listed, instead of using the date of the parsing action, we show the date when the original notification was sent.
+
 ## v0.2.4
 
 ### Fix

--- a/nautobot_circuit_maintenance/templates/nautobot_circuit_maintenance/circuitmaintenance.html
+++ b/nautobot_circuit_maintenance/templates/nautobot_circuit_maintenance/circuitmaintenance.html
@@ -233,7 +233,7 @@
                         <a href="{% url 'plugins:nautobot_circuit_maintenance:rawnotification' pk=parsed_notification.raw_notification.id %}">{{ parsed_notification.raw_notification.subject }}</a>
                     </td>
                     <td>
-                        {{ parsed_notification.date }}
+                        {{ parsed_notification.raw_notification.date }}
                     </td>
                     <td>
                         {{ parsed_notification.json }}


### PR DESCRIPTION
Addresses issue #112 
The `ParsedNotification.date` points to the date when the object (the parsed notification) was created.
Instead of this, we should show the `RawNotification` date that points to when the original notification was sent.