### PR TITLE
Remove errant comma

### DIFF
--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -271,7 +271,7 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
             logger.log_failure(
                 message=(
                     f"Unexpected exception while handling parsed notification `{notification.subject}`.\n"
-                    f"```\n{tb_str}\n```",
+                    f"```\n{tb_str}\n```"
                 )
             )
 


### PR DESCRIPTION
Remove extraneous comma that was causing `message` to be treated as a tuple instead of a string.