### PR TITLE
Avoid creating naive datetime for start_time/end_time

### DIFF
--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -32,8 +32,8 @@ def create_circuit_maintenance(
     """Handles the creation of a new circuit maintenance."""
     circuit_maintenance_entry = CircuitMaintenance(
         name=maintenance_id,
-        start_time=datetime.datetime.fromtimestamp(parser_maintenance.start),
-        end_time=datetime.datetime.fromtimestamp(parser_maintenance.end),
+        start_time=datetime.datetime.fromtimestamp(parser_maintenance.start, tz=datetime.timezone.utc),
+        end_time=datetime.datetime.fromtimestamp(parser_maintenance.end, tz=datetime.timezone.utc),
         description=parser_maintenance.summary,
         status=parser_maintenance.status,
     )
@@ -85,8 +85,12 @@ def update_circuit_maintenance(
     """Handles the update of an existent circuit maintenance."""
     circuit_maintenance_entry.description = parser_maintenance.summary
     circuit_maintenance_entry.status = parser_maintenance.status
-    circuit_maintenance_entry.start_time = datetime.datetime.fromtimestamp(parser_maintenance.start)
-    circuit_maintenance_entry.end_time = datetime.datetime.fromtimestamp(parser_maintenance.end)
+    circuit_maintenance_entry.start_time = datetime.datetime.fromtimestamp(
+        parser_maintenance.start, tz=datetime.timezone.utc
+    )
+    circuit_maintenance_entry.end_time = datetime.datetime.fromtimestamp(
+        parser_maintenance.end, tz=datetime.timezone.utc
+    )
     circuit_maintenance_entry.ack = False
     circuit_maintenance_entry.save()
 


### PR DESCRIPTION
When running the job, I noticed that Django complains about `start_time` and `end_time` being naive datetime objects rather than timezone aware:

```
django/db/models/fields/__init__.py:1370: RuntimeWarning: DateTimeField CircuitMaintenance.start_time received a naive datetime (2021-09-15 19:00:00) while time zone support is active.
```

This should fix that issue by ensuring that we explicitly recognize the `parser_maintenance` timestamps as UTC time.