### PR TITLE
Update CircuitMaintenance only newer notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fix
 
 - #113: In `CircuitMaintenace` detail view, when the parsed notifications are listed, instead of using the date of the parsing action, we show the date when the original notification was sent.
+- #123: Unordered notifications made the final `CircuitMaintenance` state to not being the latest but the one from the last notification parsed. Now, only parsed notifications, newer than the latest one used to update the `CircuitMaintenace` are taken into account, but all of them are linked to it, to have a complete report of them, and be able to render all of them in descendant order in the detail view.
 
 ## v0.2.4 - 2021-09-20
 

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -173,11 +173,10 @@ def create_or_update_circuit_maintenance(
             parser_maintenance.stamp, tz=datetime.timezone.utc
         )
         if last_parsed_notification and last_parsed_notification.date > parser_maintenance_datetime:
-            if logger.debug:
-                logger.log_debug(
-                    f"Not updating CircuitMaintenance {maintenance_id} because the notification is from "
-                    f"{parser_maintenance_datetime}, older than the most recent notification from {last_parsed_notification.date}."
-                )
+            logger.log_debug(
+                f"Not updating CircuitMaintenance {maintenance_id} because the notification is from "
+                f"{parser_maintenance_datetime}, older than the most recent notification from {last_parsed_notification.date}."
+            )
             return circuit_maintenance_entry
 
         update_circuit_maintenance(logger, circuit_maintenance_entry, maintenance_id, parser_maintenance, provider)

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -164,6 +164,9 @@ def create_or_update_circuit_maintenance(
     maintenance_id = f"{raw_entry.provider.slug}-{parser_maintenance.maintenance_id}"
     try:
         circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
+        # Using the RawNotification.date as the reference to sort because it's the one that takes into account the
+        # source receving time. The ParsedNotification.date stores the date when the RawNotification was parsed and the
+        # ParsedNotification was created.
         last_parsed_notification = (
             circuit_maintenance_entry.parsednotification_set.order_by("raw_notification__date").reverse().last()
         )

--- a/nautobot_circuit_maintenance/models.py
+++ b/nautobot_circuit_maintenance/models.py
@@ -240,6 +240,7 @@ class RawNotification(OrganizationalModel):
     sender = models.CharField(max_length=200, default="", null=True, blank=True)
     source = models.ForeignKey(NotificationSource, on_delete=models.SET_NULL, null=True)
     parsed = models.BooleanField(default=False, null=True, blank=True)
+    # RawNotification.date is the date when the RawNotification was received by the Source
     date = models.DateTimeField(default=now)
 
     class Meta:  # noqa: D106 "Missing docstring in public nested class"
@@ -281,6 +282,7 @@ class ParsedNotification(OrganizationalModel):
     maintenance = models.ForeignKey(CircuitMaintenance, on_delete=models.CASCADE, default=None)
     raw_notification = models.ForeignKey(RawNotification, on_delete=models.CASCADE, default=None)
     json = models.JSONField()
+    # ParsedNotification.date is the date when after parsing a RawNotification, the ParsedNotification was created
     date = models.DateTimeField(default=now)
 
     class Meta:  # noqa: D106 "Missing docstring in public nested class"

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -367,7 +367,7 @@ class TestHandleNotificationsJob(TestCase):
         self.assertEqual(circuit_to_update["impact"], circuit_impact_entry.impact)
 
     def test_update_circuit_maintenance_unordered_notifications(self):
-        """Test update_circuit_maintenance."""
+        """Test update_circuit_maintenance with unordered notifications."""
         notification_data = get_base_notification_data()
         test_notification_older = generate_email_notification(notification_data, self.source.name)
 

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -365,3 +365,30 @@ class TestHandleNotificationsJob(TestCase):
         self.assertEqual(notification_data["status"], circuit_maintenance_entry.status)
         circuit_impact_entry = CircuitImpact.objects.get(circuit__cid=circuit_to_update["cid"])
         self.assertEqual(circuit_to_update["impact"], circuit_impact_entry.impact)
+
+    def test_update_circuit_maintenance_unordered_notifications(self):
+        """Test update_circuit_maintenance."""
+        notification_data = get_base_notification_data()
+        test_notification_older = generate_email_notification(notification_data, self.source.name)
+
+        notification_data["status"] = "COMPLETED"
+        test_notification_newer = generate_email_notification(notification_data, self.source.name)
+        test_notification_newer.date = "Mon, 2 Feb 2021 09:33:34 +0000"
+
+        provider = Provider.objects.get(slug=test_notification_older.provider_type)
+        with patch(
+            "nautobot_circuit_maintenance.handle_notifications.handler.get_notifications"
+        ) as mock_get_notifications:
+            # We simulate that the newer notifications are retrieved first, so processed first
+            mock_get_notifications.return_value = [test_notification_newer, test_notification_older]
+            self.job.run(commit=True)
+
+        # Verify that both notifications where related to same CircuitMaintenance
+        self.assertEqual(1, len(CircuitMaintenance.objects.all()))
+
+        maintenance_id = f"{provider.slug}-{notification_data['name']}"
+        circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
+        # Verify that the final status of the CircuitMaintenance depends on the newest notification
+        self.assertEqual(circuit_maintenance_entry.status, "COMPLETED")
+        # Verify that both parsed notifications are linked to the CircuitMaintenance for future reference
+        self.assertEqual(len(circuit_maintenance_entry.parsednotification_set.all()), 2)

--- a/nautobot_circuit_maintenance/views.py
+++ b/nautobot_circuit_maintenance/views.py
@@ -35,7 +35,7 @@ class CircuitMaintenanceView(generic.ObjectView):
         maintenance_note = models.Note.objects.filter(maintenance=instance)
         circuits = models.CircuitImpact.objects.filter(maintenance=instance)
         parsednotification = models.ParsedNotification.objects.filter(maintenance=instance).order_by(
-            "raw_notification__date"
+            "-raw_notification__date"
         )
 
         return {

--- a/nautobot_circuit_maintenance/views.py
+++ b/nautobot_circuit_maintenance/views.py
@@ -34,7 +34,9 @@ class CircuitMaintenanceView(generic.ObjectView):
         """Extend content of detailed view for Circuit Maintenance."""
         maintenance_note = models.Note.objects.filter(maintenance=instance)
         circuits = models.CircuitImpact.objects.filter(maintenance=instance)
-        parsednotification = models.ParsedNotification.objects.filter(maintenance=instance)
+        parsednotification = models.ParsedNotification.objects.filter(maintenance=instance).order_by(
+            "raw_notification__date"
+        )
 
         return {
             "circuits": circuits,


### PR DESCRIPTION
Addresses issue #112 

In order to parse notification in **any** order but keep the latest one as the final state, before updating an existing `CircuitMaintenance` we take into account the notification `stamp`, so only the newer ones are taken into account in the final state, but all the parsed notifications are listed in the final `CircuitMaintenance` ordering them via this stamp (HTML template updated)

In the UI test, I had to notifications for the same Maintenance, and now (in debug mode), we see that we are hitting the "Not update CircuitMaintenance...", but the notification is created the same way, and in the rendering is showed in the proper order.

![image](https://user-images.githubusercontent.com/15998111/135414549-7312209e-caae-4774-b48a-5f310c66ba9f.png)


![image](https://user-images.githubusercontent.com/15998111/135414167-8703c0a3-57f3-41a8-b7e1-cdd44625999c.png)
