### PR TITLE
Increase RawNotifications raw size and used defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,8 @@ PLUGINS = ["nautobot_circuit_maintenance"]
 ```py
 PLUGINS_CONFIG = {
     "nautobot_circuit_maintenance": {
-        "raw_notifications": {
-            "initial_days_since": 100,
-            "raw_notification_size": 500,
-        },
+        "raw_notification_initial_days_since": 100,
+        "raw_notification_size": 16384,
         "notification_sources": [
             {
               ...
@@ -43,12 +41,12 @@ PLUGINS_CONFIG = {
 }
 ```
 
-In the `raw_notifications` section, you can define:
+Plugin config parameters:
 
-- `initial_days_since`: define how many days back the plugin will check for `RawNotification`s for each
+- `raw_notification_initial_days_since`: define how many days back the plugin will check for `RawNotification`s for each
   `NotificationSource`, in order to limit the number of notifications to be processed on the first run of the plugin.
   In subsequent runs, the last notification date will be used as the reference to limit. If not defined, it defaults to **365 days**.
-- `raw_notification_size`: define how many bytes from a notification will be stored in the database to not store too big objects. If not defined, it defaults to **1000** bytes.
+- `raw_notification_size`: define how many bytes from a notification will be stored in the database to not store too big objects. If not defined, it defaults to **8192** bytes.
 
 The `notification_sources` have custom definition depending on the `Source` type, and are defined in the [Usage](#Usage) section.
 

--- a/development/nautobot_config.py
+++ b/development/nautobot_config.py
@@ -241,7 +241,6 @@ PLUGINS = ["nautobot_circuit_maintenance"]
 # Each key in the dictionary is the name of an installed plugin and its value is a dictionary of settings.
 PLUGINS_CONFIG = {
     "nautobot_circuit_maintenance": {
-        "raw_notifications": {"initial_days_since": 365},
         "notification_sources": [
             {
                 "name": "my imap source",

--- a/nautobot_circuit_maintenance/__init__.py
+++ b/nautobot_circuit_maintenance/__init__.py
@@ -84,7 +84,12 @@ class CircuitMaintenanceConfig(PluginConfig):
     min_version = "1.0.0-beta.4"
     max_version = "1.999"
     required_settings = []
-    default_settings = {}
+    default_settings = {
+        "raw_notifications": {
+            "initial_days_since": 365,
+            "raw_notification_size": 8192,
+        },
+    }
     caching_config = {}
 
     def ready(self):

--- a/nautobot_circuit_maintenance/__init__.py
+++ b/nautobot_circuit_maintenance/__init__.py
@@ -85,10 +85,8 @@ class CircuitMaintenanceConfig(PluginConfig):
     max_version = "1.999"
     required_settings = []
     default_settings = {
-        "raw_notifications": {
-            "initial_days_since": 365,
-            "raw_notification_size": 8192,
-        },
+        "raw_notification_initial_days_since": 365,
+        "raw_notification_size": 8192,
     }
     caching_config = {}
 

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -303,14 +303,14 @@ def process_raw_notification(logger: Job, notification: MaintenanceNotification)
 
 
 def get_since_reference(logger: Job) -> int:
-    """Get the timestamp from the latest processed RawNotification or a reference from config `initial_days_since`."""
+    """Get the timestamp from the latest processed RawNotification or a reference from config `raw_notification_initial_days_since`."""
     # Latest retrieved notification will limit the scope of notifications to retrieve
     last_raw_notification = RawNotification.objects.last()
     if last_raw_notification:
         since_reference = last_raw_notification.date.timestamp()
     else:
         since_reference = datetime.datetime.utcnow() - datetime.timedelta(
-            days=PLUGIN_SETTINGS.get("raw_notifications", {}).get("initial_days_since")
+            days=PLUGIN_SETTINGS.get("raw_notification_initial_days_since")
         )
         since_reference = int(since_reference.timestamp())
     logger.log_info(message=f"Processing notifications since {since_reference}")

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -22,7 +22,6 @@ from .sources import get_notifications, MaintenanceNotification
 
 # pylint: disable=broad-except
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG.get("nautobot_circuit_maintenance", {})
-MAX_INITIAL_DAYS_SINCE = 365
 
 
 def create_circuit_maintenance(
@@ -311,7 +310,7 @@ def get_since_reference(logger: Job) -> int:
         since_reference = last_raw_notification.date.timestamp()
     else:
         since_reference = datetime.datetime.utcnow() - datetime.timedelta(
-            days=PLUGIN_SETTINGS.get("raw_notifications", {}).get("initial_days_since", MAX_INITIAL_DAYS_SINCE)
+            days=PLUGIN_SETTINGS.get("raw_notifications", {}).get("initial_days_since")
         )
         since_reference = int(since_reference.timestamp())
     logger.log_info(message=f"Processing notifications since {since_reference}")

--- a/nautobot_circuit_maintenance/models.py
+++ b/nautobot_circuit_maintenance/models.py
@@ -249,7 +249,7 @@ class RawNotification(OrganizationalModel):
     def save(self, *args, **kwargs):
         """Custom save for RawNotification."""
         # Limiting the size of the notification stored.
-        self.raw = self.raw[: PLUGIN_SETTINGS.get("raw_notifications", {}).get("raw_notification_size")]
+        self.raw = self.raw[: PLUGIN_SETTINGS.get("raw_notification_size")]
         super().save(*args, **kwargs)
 
     def __str__(self):

--- a/nautobot_circuit_maintenance/models.py
+++ b/nautobot_circuit_maintenance/models.py
@@ -15,7 +15,6 @@ from nautobot.core.models.generics import PrimaryModel, OrganizationalModel
 from .choices import CircuitImpactChoices, CircuitMaintenanceStatusChoices, NoteLevelChoices
 
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG.get("nautobot_circuit_maintenance", {})
-DEFAULT_RAW_NOTIFICATION_SIZE = 1000
 
 
 @extras_features(
@@ -250,9 +249,7 @@ class RawNotification(OrganizationalModel):
     def save(self, *args, **kwargs):
         """Custom save for RawNotification."""
         # Limiting the size of the notification stored.
-        self.raw = self.raw[
-            : PLUGIN_SETTINGS.get("raw_notifications", {}).get("raw_notification_size", DEFAULT_RAW_NOTIFICATION_SIZE)
-        ]
+        self.raw = self.raw[: PLUGIN_SETTINGS.get("raw_notifications", {}).get("raw_notification_size")]
         super().save(*args, **kwargs)
 
     def __str__(self):


### PR DESCRIPTION
Addresses #116 
* Use Plugin default settings
* Increase size of raw notification stored: all the headers are included.