### PR TITLE
Improve response time of app metrics endpoint

### DIFF
--- a/nautobot_circuit_maintenance/metrics_app.py
+++ b/nautobot_circuit_maintenance/metrics_app.py
@@ -60,7 +60,7 @@ def metric_circuit_operational():
         .prefetch_related("circuit")
     )
 
-    for termination in CircuitTermination.objects.all().prefetch_related("circuit"):
+    for termination in CircuitTermination.objects.all().select_related("circuit", "circuit__provider", "circuit__type", "site"):
         status = 1
         if any(circuit_impact.circuit == termination.circuit for circuit_impact in active_circuit_impacts):
             status = 2

--- a/nautobot_circuit_maintenance/metrics_app.py
+++ b/nautobot_circuit_maintenance/metrics_app.py
@@ -60,7 +60,9 @@ def metric_circuit_operational():
         .prefetch_related("circuit")
     )
 
-    for termination in CircuitTermination.objects.all().select_related("circuit", "circuit__provider", "circuit__type", "site"):
+    for termination in CircuitTermination.objects.all().select_related(
+        "circuit", "circuit__provider", "circuit__type", "site"
+    ):
         status = 1
         if any(circuit_impact.circuit == termination.circuit for circuit_impact in active_circuit_impacts):
             status = 2

--- a/nautobot_circuit_maintenance/metrics_app.py
+++ b/nautobot_circuit_maintenance/metrics_app.py
@@ -22,6 +22,9 @@ def rgetattr(obj, attr, *args):
 
 
 PLUGIN_SETTINGS = settings.PLUGINS_CONFIG.get("nautobot_circuit_maintenance", {})
+# REMINDER
+# If we update the list of default labels, we should also update
+# the list of select_related fields for the query in metric_circuit_operational
 DEFAULT_LABELS = {
     "circuit": "circuit.cid",
     "provider": "circuit.provider.name",


### PR DESCRIPTION
After enabling the app metrics endpoint in a production environment we noticed that the response time was between 3 and 5 seconds for few hundred circuits. 

After some investigation, I was able to reduce the response time significantly by adding some select_related tables to the main query.
In my test enviroments, it improved the response time by 100x