### PR TITLE
Use case-insensitive lookups when matching CIDs to Circuits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- Circuit CID lookups are now case-insensitive
+- #156: Circuit CID lookups are now case-insensitive
 
 ## v0.3.2 - 2021-10-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - #120: Added option to apply appropriate labels to Gmail messages after processing them.
 
+### Changed
+
+- Circuit CID lookups are now case-insensitive
+
 ## v0.3.2 - 2021-10-26
 
 ### Fixed

--- a/nautobot_circuit_maintenance/fixtures/handle_notifications_job.yaml
+++ b/nautobot_circuit_maintenance/fixtures/handle_notifications_job.yaml
@@ -60,7 +60,7 @@
     last_updated: 2021-04-30 07:43:34.845865+00:00
     _custom_field_data: {}
     status: null
-    cid: "000001"
+    cid: "CID-000001"
     provider: "0ec89992-0de0-483f-8f53-bdcd179eaecd"
     type: "d1c2ed9d-9376-485b-b058-d26c29b5f22f"
     tenant: null
@@ -75,7 +75,7 @@
     last_updated: 2021-05-06 05:18:36.057186+00:00
     _custom_field_data: {}
     status: null
-    cid: "000002"
+    cid: "CID-000002"
     provider: "0ec89992-0de0-483f-8f53-bdcd179eaecd"
     type: "d1c2ed9d-9376-485b-b058-d26c29b5f22f"
     tenant: null

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -91,7 +91,9 @@ def get_base_notification_data(provider_slug="ntt") -> dict:
 
     sample_circuits = Circuit.objects.filter(provider=provider)
     for circuit in sample_circuits:
-        notification_data["circuitimpacts"].append({"cid": circuit.cid, "impact": "NO-IMPACT"})
+        # Intentionally convert the CID reference to lower-case,
+        # because all of our circuit lookups *should* be case-insensitive
+        notification_data["circuitimpacts"].append({"cid": circuit.cid.lower(), "impact": "NO-IMPACT"})
 
     return notification_data
 
@@ -415,7 +417,7 @@ class TestHandleNotificationsJob(TestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(1, len(Note.objects.all()))
         circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
         self.assertEqual(notification_data["status"], circuit_maintenance_entry.status)
-        circuit_impact_entry = CircuitImpact.objects.get(circuit__cid=circuit_to_update["cid"])
+        circuit_impact_entry = CircuitImpact.objects.get(circuit__cid__iexact=circuit_to_update["cid"])
         self.assertEqual(circuit_to_update["impact"], circuit_impact_entry.impact)
 
     def test_update_circuit_maintenance_unordered_notifications(self):


### PR DESCRIPTION
Human data entry being what it is, I've encountered a number of cases where the capitalization of CIDs in notification emails differs from the capitalization of the CIDs in the Nautobot database. This PR allows the plugin to gracefully handle such differences by using case-insensitive comparisons and logic where appropriate.