### PR TITLE
Fix for ascii decode issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.1
+
+### Fixed
+
+- #158: Removed `utf-8` decoding for `IMAP` source to support for `ascii` encoded emails.
+
 ## v0.4.0 - 2021-11-11
 
 ### Added

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -346,9 +346,6 @@ class IMAP(EmailSource):
     def fetch_email(self, job_logger: Job, msg_id: bytes) -> Optional[MaintenanceNotification]:
         """Fetch an specific email ID."""
         _, data = self.session.fetch(msg_id, "(RFC822)")
-        # raw_email_string = data[0][1].decode("utf-8")
-        # email_message = email.message_from_string(raw_email_string)
-        # raw_email_string = data[0][1].decode("utf-8")
         email_message = email.message_from_bytes(data[0][1])
 
         return self.process_email(job_logger, email_message, msg_id)

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -346,8 +346,10 @@ class IMAP(EmailSource):
     def fetch_email(self, job_logger: Job, msg_id: bytes) -> Optional[MaintenanceNotification]:
         """Fetch an specific email ID."""
         _, data = self.session.fetch(msg_id, "(RFC822)")
-        raw_email_string = data[0][1].decode("utf-8")
-        email_message = email.message_from_string(raw_email_string)
+        # raw_email_string = data[0][1].decode("utf-8")
+        # email_message = email.message_from_string(raw_email_string)
+        # raw_email_string = data[0][1].decode("utf-8")
+        email_message = email.message_from_bytes(data[0][1])
 
         return self.process_email(job_logger, email_message, msg_id)
 


### PR DESCRIPTION
This PR fixes #152 removing the `utf-8` decoding for email messages and letting the library detect the encoding.
 