### PR TITLE
Always refresh token when calling test_authentication(); add admin to delete NotificationSources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v0.4.1
+## v0.4.2
+
+### Fixed
+
+- #162 - Fix inability to refresh OAuth authentication before token expires
+
+## v0.4.1 - 2021-11-29
 
 ### Fixed
 

--- a/nautobot_circuit_maintenance/admin.py
+++ b/nautobot_circuit_maintenance/admin.py
@@ -1,0 +1,17 @@
+"""Admin management content for this plugin."""
+
+from django.contrib import admin
+from .models import NotificationSource
+
+
+@admin.register(NotificationSource)
+class NotificationSourceAdmin(admin.ModelAdmin):
+    """Admin capabilities for viewing and deleting NotificationSource records."""
+
+    def has_add_permission(self, request):
+        """No option to add NotificationSources via the admin - use nautobot_config.py definitions instead."""
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        """No option to change NotificationSources via the admin - use nautobot_config.py definitions instead."""
+        return False

--- a/nautobot_circuit_maintenance/handle_notifications/sources.py
+++ b/nautobot_circuit_maintenance/handle_notifications/sources.py
@@ -431,7 +431,7 @@ class GmailAPI(EmailSource):
 
         arbitrary_types_allowed = True
 
-    def load_credentials(self):
+    def load_credentials(self, force_refresh=False):
         """Load Credentials for Gmail API."""
         raise NotImplementedError
 
@@ -446,7 +446,7 @@ class GmailAPI(EmailSource):
 
     def _authentication_logic(self):
         """Inner method to run the custom class validation logic."""
-        self.load_credentials()
+        self.load_credentials(force_refresh=True)
 
     def extract_raw_payload(self, body: Dict, msg_id: str) -> bytes:
         """Extracts the raw_payload from body or attachement."""
@@ -580,7 +580,7 @@ class GmailAPIOauth(GmailAPI):
     See: https://developers.google.com/identity/protocols/oauth2/web-server
     """
 
-    def load_credentials(self):
+    def load_credentials(self, force_refresh=False):
         """Load Gmail API OAuth credentials."""
         notification_source = NotificationSource.objects.get(name=self.name)
         try:
@@ -588,8 +588,8 @@ class GmailAPIOauth(GmailAPI):
         except EOFError:
             logger.debug("Google OAuth Token has not been initialized yet.")
 
-        if not self.credentials or not self.credentials.valid:
-            if self.credentials and self.credentials.expired and self.credentials.refresh_token:
+        if force_refresh or not self.credentials or not self.credentials.valid:
+            if self.credentials and self.credentials.refresh_token and (self.credentials.expired or force_refresh):
                 self.credentials.refresh(Request())
                 notification_source.token = self.credentials
                 notification_source.save()
@@ -603,9 +603,9 @@ class GmailAPIOauth(GmailAPI):
 class GmailAPIServiceAccount(GmailAPI):
     """GmailAPIServiceAccount class."""
 
-    def load_credentials(self):
+    def load_credentials(self, force_refresh=False):
         """Load Gmail API Service Account credentials."""
-        if not self.credentials:
+        if force_refresh or not self.credentials:
             self.credentials = service_account.Credentials.from_service_account_file(self.credentials_file)
             self.credentials = self.credentials.with_scopes(self.SCOPES + self.extra_scopes)
             self.credentials = self.credentials.with_subject(self.account)


### PR DESCRIPTION
Fixes #162, in theory (as usual it's really not feasible to actually test the OAuth workflow locally).

- Add capability in the Admin UI to manually delete NotificationSource records, forcing their recreation when Nautobot is restarted (useful in the case where a NotificationSource has a bad `token` and it's not feasible to access `nbshell`)
- Add a `force_refresh` flag to the `load_credentials()` method and set this flag to `True` in the case of `test_authentication` calling it.