### PR TITLE
Handle NO-CHANGE status and unknown status values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - #162 - Fix inability to refresh OAuth authentication before token expires
+- #166 - Handle `NO-CHANGE` status from parser (networktocode/circuit-maintenance-parser#125), handle unknown statuses from parser, fix potential error during `nautobot-server post_migrate` signal handling.
 
 ## v0.4.1 - 2021-11-29
 

--- a/nautobot_circuit_maintenance/choices.py
+++ b/nautobot_circuit_maintenance/choices.py
@@ -18,6 +18,8 @@ class CircuitMaintenanceStatusChoices(ChoiceSet):
     COMPLETED = "COMPLETED"
     RE_SCHEDULED = "RE-SCHEDULED"
 
+    UNKNOWN = "UNKNOWN"
+
     CHOICES = (
         (TENTATIVE, "TENTATIVE"),
         (CONFIRMED, "CONFIRMED"),
@@ -25,6 +27,7 @@ class CircuitMaintenanceStatusChoices(ChoiceSet):
         (IN_PROCESS, "IN-PROCESS"),
         (COMPLETED, "COMPLETED"),
         (RE_SCHEDULED, "RE-SCHEDULED"),
+        (UNKNOWN, "UNKNOWN"),
     )
 
 

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from jinja2 import Template
 from nautobot.circuits.models import Circuit, Provider
 from circuit_maintenance_parser import init_provider, NotificationData
+from circuit_maintenance_parser.output import Status
 
 from nautobot_circuit_maintenance.handle_notifications.handler import (
     create_circuit_maintenance,
@@ -387,6 +388,38 @@ class TestHandleNotificationsJob(TestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(1, len(Note.objects.all()))
         mock_tag_message.assert_called_with(self.job, test_notification.msg_id, "unknown-cids")
 
+    def test_create_circuit_maintenance_unknown_status(self):
+        """Test create_circuit_maintenance with an unknown status."""
+        notification_data = get_base_notification_data()
+        test_notification = generate_email_notification(notification_data, self.source)
+        provider = Provider.objects.get(slug=test_notification.provider_type)
+        RawNotification.objects.get_or_create(
+            subject=test_notification.subject,
+            provider=provider,
+            raw=test_notification.raw_payload,
+            sender=test_notification.sender,
+            source=self.notification_source,
+            stamp=datetime.now(timezone.utc),
+        )
+        parser_provider = init_provider(provider_type=test_notification.provider_type)
+        data_to_process = NotificationData.init_from_email_bytes(test_notification.raw_payload)
+        parsed_maintenance = parser_provider.get_maintenances(data_to_process)[0]
+        parsed_maintenance.status = "No idea!"
+        with patch("nautobot_circuit_maintenance.handle_notifications.sources.Source.tag_message") as mock_tag_message:
+            create_circuit_maintenance(
+                self.job,
+                test_notification,
+                f"{provider.slug}-{parsed_maintenance.maintenance_id}",
+                parsed_maintenance,
+                provider,
+            )
+
+        self.assertEqual(1, len(CircuitMaintenance.objects.all()))
+        self.assertEqual(2, len(CircuitImpact.objects.all()))
+        self.assertEqual(0, len(Note.objects.all()))
+
+        self.assertEqual("UNKNOWN", CircuitMaintenance.objects.first().status)
+
     def test_update_circuit_maintenance(self):
         """Test update_circuit_maintenance."""
         notification_data = get_base_notification_data()
@@ -450,6 +483,31 @@ class TestHandleNotificationsJob(TestCase):  # pylint: disable=too-many-public-m
         self.assertEqual(circuit_maintenance_entry.status, "COMPLETED")
         # Verify that both parsed notifications are linked to the CircuitMaintenance for future reference
         self.assertEqual(len(circuit_maintenance_entry.parsednotification_set.all()), 2)
+
+    def test_update_circuit_maintenance_status_no_change(self):
+        """Test update_circuit_maintenance with a "NO-CHANGE" status value."""
+        notification_data = get_base_notification_data()
+        test_notification = generate_email_notification(notification_data, self.source)
+        provider = Provider.objects.get(slug=test_notification.provider_type)
+        with patch(
+            "nautobot_circuit_maintenance.handle_notifications.handler.get_notifications"
+        ) as mock_get_notifications:
+            mock_get_notifications.return_value = [test_notification]
+            self.job.run(commit=True)
+
+        # Adding changes
+        parser_provider = init_provider(provider_type=test_notification.provider_type)
+        data_to_process = NotificationData.init_from_email_bytes(test_notification.raw_payload)
+        parsed_maintenance = parser_provider.get_maintenances(data_to_process)[0]
+        parsed_maintenance.status = "NO-CHANGE"
+        maintenance_id = f"{provider.slug}-{parsed_maintenance.maintenance_id}"
+        circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
+
+        update_circuit_maintenance(self.job, test_notification, circuit_maintenance_entry, parsed_maintenance, provider)
+
+        circuit_maintenance_entry = CircuitMaintenance.objects.get(name=maintenance_id)
+        # Status should not be changed:
+        self.assertEqual("CONFIRMED", circuit_maintenance_entry.status)
 
     def test_create_or_update_circuit_maintenance_truncated_fields(self):
         """Test create_or_update_circuit_maintenance with long fields that must be truncated to fit the DB."""

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -7,7 +7,6 @@ from django.test import TestCase
 from jinja2 import Template
 from nautobot.circuits.models import Circuit, Provider
 from circuit_maintenance_parser import init_provider, NotificationData
-from circuit_maintenance_parser.output import Status
 
 from nautobot_circuit_maintenance.handle_notifications.handler import (
     create_circuit_maintenance,
@@ -405,14 +404,13 @@ class TestHandleNotificationsJob(TestCase):  # pylint: disable=too-many-public-m
         data_to_process = NotificationData.init_from_email_bytes(test_notification.raw_payload)
         parsed_maintenance = parser_provider.get_maintenances(data_to_process)[0]
         parsed_maintenance.status = "No idea!"
-        with patch("nautobot_circuit_maintenance.handle_notifications.sources.Source.tag_message") as mock_tag_message:
-            create_circuit_maintenance(
-                self.job,
-                test_notification,
-                f"{provider.slug}-{parsed_maintenance.maintenance_id}",
-                parsed_maintenance,
-                provider,
-            )
+        create_circuit_maintenance(
+            self.job,
+            test_notification,
+            f"{provider.slug}-{parsed_maintenance.maintenance_id}",
+            parsed_maintenance,
+            provider,
+        )
 
         self.assertEqual(1, len(CircuitMaintenance.objects.all()))
         self.assertEqual(2, len(CircuitImpact.objects.all()))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-circuit-maintenance"
-version = "0.4.1"
+version = "0.4.2"
 description = "Nautobot plugin to automatically handle Circuit Maintenances Notifications"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 


### PR DESCRIPTION
Counterpart to https://github.com/networktocode/circuit-maintenance-parser/pull/125:

- if the parser library reports a status of `NO-CHANGE`, do not update the status of an existing CircuitMaintenance.
- if the parser library reports a status value that we don't understand (including `NO-CHANGE` for the first notification we see for a given maintenance), set the CircuitMaintenance status to `UNKNOWN`.
- Bump the version to 0.4.2 in preparation for an upcoming release.