### PR TITLE
Limit string representations to a max of 200 characters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.4.3
+
+### Fixed
+
+- #172 - Fix potential `DataError: value too long for type` when handling especially long email subjects
+
 ## v0.4.2
 
 ### Fixed

--- a/nautobot_circuit_maintenance/models.py
+++ b/nautobot_circuit_maintenance/models.py
@@ -110,7 +110,8 @@ class CircuitImpact(OrganizationalModel):
 
     def __str__(self):
         """String value for HTML rendering."""
-        return f"Circuit {self.circuit} with impact {self.impact}"
+        # str(self) is used in change logging, and ObjectChange.object_repr field is limited to 200 characters.
+        return f"Circuit {self.circuit} with impact {self.impact}"[:200]
 
     def get_absolute_url(self):
         """Returns reverse loop up URL."""
@@ -151,7 +152,8 @@ class Note(OrganizationalModel):
 
     def __str__(self):
         """String value for HTML rendering."""
-        return f"{self.title}"
+        # str(self) is used in change logging, and ObjectChange.object_repr field is limited to 200 characters.
+        return f"{self.title}"[:200]
 
     def get_absolute_url(self):
         """Returns reverse loop up URL."""
@@ -298,7 +300,8 @@ class ParsedNotification(OrganizationalModel):
 
     def __str__(self):
         """String value for HTML rendering."""
-        return f"Parsed notification for {self.raw_notification.subject}"
+        # str(self) is used in change logging, and ObjectChange.object_repr field is limited to 200 characters.
+        return f"Parsed notification for {self.raw_notification.subject}"[:200]
 
     def get_absolute_url(self):
         """Returns reverse loop up URL."""


### PR DESCRIPTION
A `RawNotification.subject` has a length limit of 200 characters (which we are already correctly truncating email subject lines to fit within), but `str(ParsedNotification)` renders as `"Parsed notification for {self.raw_notification.subject}"`, so it can potentially exceed 200 characters. Unfortunately the core Nautobot change logging model `ObjectChange` has a field, `object_repr`, which contains the `str()` representation of the changed object and has a 200-character length limit. Thus, as encountered in a customer deployment, processing an email whose subject line approaches 200 characters may result in an exception like the following when creating the ObjectChange for a ParsedNotification:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.7/site-packages/newrelic/hooks/database_psycopg2.py", line 65, in execute
    **kwargs)
  File "/usr/local/lib/python3.7/site-packages/newrelic/hooks/database_dbapi2.py", line 38, in execute
    *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django_prometheus/db/common.py", line 71, in execute
    return super().execute(*args, **kwargs)
psycopg2.errors.StringDataRightTruncation: value too long for type character varying(200)


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/nautobot_circuit_maintenance/handle_notifications/handler.py", line 327, in process_raw_notification
    json=parser_maintenance.to_json(),
  File "/usr/local/lib/python3.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/query.py", line 447, in create
    obj.save(force_insert=True, using=self.db)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 754, in save
    force_update=force_update, update_fields=update_fields)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 803, in save_base
    update_fields=update_fields, raw=raw, using=using,
  File "/usr/local/lib/python3.7/site-packages/django/dispatch/dispatcher.py", line 179, in send
    for receiver in self._live_receivers(sender)
  File "/usr/local/lib/python3.7/site-packages/django/dispatch/dispatcher.py", line 179, in 
    for receiver in self._live_receivers(sender)
  File "/usr/local/lib/python3.7/site-packages/nautobot/utilities/utils.py", line 311, in _curried
    return _curried_func(*args, *moreargs, **{**kwargs, **morekwargs})
  File "/usr/local/lib/python3.7/site-packages/nautobot/extras/signals.py", line 64, in _handle_changed_object
    objectchange.save()
  File "/usr/local/lib/python3.7/site-packages/nautobot/extras/models/change_logging.py", line 113, in save
    return super().save(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 754, in save
    force_update=force_update, update_fields=update_fields)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 792, in save_base
    force_update, using, update_fields,
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 895, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/base.py", line 935, in _do_insert
    using=using, raw=raw,
  File "/usr/local/lib/python3.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/query.py", line 1254, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/usr/local/lib/python3.7/site-packages/django/db/models/sql/compiler.py", line 1397, in execute_sql
    cursor.execute(sql, params)
  File "/usr/local/lib/python3.7/site-packages/cacheops/transaction.py", line 93, in execute
    result = self._no_monkey.execute(self, sql, params)
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.7/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/usr/local/lib/python3.7/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python3.7/site-packages/newrelic/hooks/database_psycopg2.py", line 65, in execute
    **kwargs)
  File "/usr/local/lib/python3.7/site-packages/newrelic/hooks/database_dbapi2.py", line 38, in execute
    *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/django_prometheus/db/common.py", line 71, in execute
    return super().execute(*args, **kwargs)
django.db.utils.DataError: value too long for type character varying(200)
```


The solution I've implemented here is to explicitly truncate the string representations of models that may encounter this issue to a maximum of 200 characters.