### PR TITLE
Show appropriate side a and z terminations in circuitmaintenance view

### DIFF
--- a/nautobot_circuit_maintenance/templates/nautobot_circuit_maintenance/circuitmaintenance.html
+++ b/nautobot_circuit_maintenance/templates/nautobot_circuit_maintenance/circuitmaintenance.html
@@ -143,10 +143,22 @@
                         {% endif %}
                     </td>
                     <td>
-                        {{ circuit.circuit.termination_a.site }}
+                    {% if circuit.circuit.termination_a.location %}
+                        {{ circuit.circuit.termination_a.location }}
+                    {% elif circuit.circuit.termination_a.provider_network %}
+                        {{ circuit.circuit.termination_a.provider_network }}
+                    {% else %}
+                        {{ circuit.circuit.termination_a.site | placeholder }}
+                    {% endif %}
                     </td>
                     <td>
-                        {{ circuit.circuit.termination_z.site }}
+                    {% if circuit.circuit.termination_z.location %}
+                        {{ circuit.circuit.termination_z.location }}
+                    {% elif circuit.circuit.termination_z.provider_network %}
+                        {{ circuit.circuit.termination_z.provider_network }}
+                    {% else %}
+                        {{ circuit.circuit.termination_z.site | placeholder }}
+                    {% endif %}
                     </td>
                     <td>
                         {{ circuit.circuit.description }}

--- a/nautobot_circuit_maintenance/templates/nautobot_circuit_maintenance/circuitmaintenance.html
+++ b/nautobot_circuit_maintenance/templates/nautobot_circuit_maintenance/circuitmaintenance.html
@@ -144,20 +144,20 @@
                     </td>
                     <td>
                     {% if circuit.circuit.termination_a.location %}
-                        {{ circuit.circuit.termination_a.location }}
+                        <a href="{{ circuit.circuit.termination_a.location.get_absolute_url }}">{{ circuit.circuit.termination_a.location }}</a>
                     {% elif circuit.circuit.termination_a.provider_network %}
-                        {{ circuit.circuit.termination_a.provider_network }}
+                        <a href="{{ circuit.circuit.termination_a.provider_network.get_absolute_url }}">{{ circuit.circuit.termination_a.provider_network }}</a>
                     {% else %}
-                        {{ circuit.circuit.termination_a.site | placeholder }}
+                        <a href="{{ circuit.circuit.termination_a.site.get_absolute_url }}">{{ circuit.circuit.termination_a.site }}</a>
                     {% endif %}
                     </td>
                     <td>
                     {% if circuit.circuit.termination_z.location %}
-                        {{ circuit.circuit.termination_z.location }}
+                        <a href="{{ circuit.circuit.termination_z.location.get_absolute_url }}">{{ circuit.circuit.termination_z.location }}</a>
                     {% elif circuit.circuit.termination_z.provider_network %}
-                        {{ circuit.circuit.termination_z.provider_network }}
+                        <a href="{{ circuit.circuit.termination_z.provider_network.get_absolute_url }}">{{ circuit.circuit.termination_z.provider_network }}</a>
                     {% else %}
-                        {{ circuit.circuit.termination_z.site | placeholder }}
+                        <a href="{{ circuit.circuit.termination_z.site.get_absolute_url }}">{{ circuit.circuit.termination_z.site }}</a>
                     {% endif %}
                     </td>
                     <td>


### PR DESCRIPTION
Fixes #198 

The placeholder at the end shouldn't really be hit, but just there in case.