### PR TITLE
Fix RTD build errors

### DIFF
--- a/docs/dev/arch_decision.md
+++ b/docs/dev/arch_decision.md
@@ -2,4 +2,4 @@
 
 ## Circuit Maintenance Parser
 
-The Circuit Maintenance Parser library is separated from the Nautobot Plugin to increase it's usability outside of situations where Nautobot may not be installed or may be too heavy of tool in a specific use case. This also allows us to decouple plugin development from parser development.
+The Circuit Maintenance Parser library is separated from the Nautobot Plugin to increase its usability outside of situations where Nautobot may not be installed or may be too heavy of tool in a specific use case. This also allows us to decouple plugin development from parser development.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,7 +107,12 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
-          - v1.0: "admin/release_notes/version_1.0.md"
+          - v0.6: "admin/release_notes/version_0.6.md"
+          - v0.5: "admin/release_notes/version_0.5.md"
+          - v0.4: "admin/release_notes/version_0.4.md"
+          - v0.3: "admin/release_notes/version_0.3.md"
+          - v0.2: "admin/release_notes/version_0.2.md"
+          - v0.1: "admin/release_notes/version_0.1.md"
   - Developer Guide:
       - Extending the App: "dev/extending.md"
       - Contributing to the App: "dev/contributing.md"
@@ -115,6 +120,8 @@ nav:
       - Architecture Decision Records: "dev/arch_decision.md"
       - Code Reference:
           - "dev/code_reference/index.md"
+          - Jobs: "dev/code_reference/jobs.md"
+          - Handle Notifications: "dev/code_reference/handle_notifications.md"
           - Package: "dev/code_reference/package.md"
           - API: "dev/code_reference/api.md"
   - Nautobot Docs Home ↗︎: "https://docs.nautobot.com"

--- a/nautobot_circuit_maintenance/jobs/site_search.py
+++ b/nautobot_circuit_maintenance/jobs/site_search.py
@@ -15,7 +15,7 @@ CIRCUIT_MAINTENANCE_TAG_COLOR = "Purple"
 name = "Circuit Maintenance"  # pylint: disable=invalid-name
 
 
-def check_for_overlap(record1: CircuitMaintenance, record2: CircuitMaintenance):
+def check_for_overlap(record1: CircuitMaintenance, record2: CircuitMaintenance) -> bool:
     """Checks for the overlap of two circuit maintenance records.
 
     Args:
@@ -49,7 +49,7 @@ def get_sites_from_circuit(circuit: Circuit) -> set:
     return site_set
 
 
-def build_sites_to_maintenance_mapper(maintenance_queryset):
+def build_sites_to_maintenance_mapper(maintenance_queryset) -> dict:
     """Build a site to circuit maintenance mapper so the data can be quickly accessed of what possible overlaps.
 
     Leverages defaultdict to provide the default value of an empty set to each key that will be added. Then adds each
@@ -94,9 +94,6 @@ class FindSitesWithMaintenanceOverlap(Job):
 
     Future iterations may include the ability to search for multiple circuit overlaps that would allow for just a single
     circuit to be available.
-
-    Args:
-        Job (Nautobot Job): Nautobot Job parent class
     """
 
     job_debug = BooleanVar(description="Enable for more verbose debug logging")


### PR DESCRIPTION
Fixes #245 

Added missing files to mkdocs nav index.
Fixed a bunch of `mkdocstrings/griffe` warnings.

This is the only solution I could find - I think it doesn't like the fact that there's no explicit constructor to map to the `Args` piece. It's not exactly a big loss I think... but perhaps someone has a better solution?

```
-    Args:
-        Job (Nautobot Job): Nautobot Job parent class
```

Error being

```
Parameter 'Job' does not appear in the function signature
```