### PR TITLE
Align with develop

### DIFF
--- a/changes/267.fixed
+++ b/changes/267.fixed
@@ -1,0 +1,1 @@
+Fixed (by removing) dependency `google-oauth`.

--- a/changes/268.changed
+++ b/changes/268.changed
@@ -1,0 +1,1 @@
+Migrated to Python 3.8 as minimum.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,14 +39,14 @@ django-debug-toolbar = "*"
 # we need to pin flake8 because of package dependencies that cause it to downgrade and
 # therefore cause issues with linting since older versions do not take .flake8 as config
 flake8 = "^3.9.2"
-griffe = "0.30.1"               # Last version with python 3.7 support
+griffe = "0.30.1"
 invoke = "*"
 ipython = "*"
 mkdocs = "1.4.3"
 mkdocs-material = "9.1.15"
 mkdocs-version-annotations = "1.0.0"
-mkdocstrings = "0.22.0"         # Last version with python 3.7 support
-mkdocstrings-python = "1.1.2"   # Last version with python 3.7 support
+mkdocstrings = "0.22.0"
+mkdocstrings-python = "1.1.2"
 parameterized = "*"
 pydocstyle = "*"
 pylint = "*"

--- a/tasks.py
+++ b/tasks.py
@@ -46,7 +46,7 @@ namespace = Collection("nautobot_circuit_maintenance")
 namespace.configure(
     {
         "nautobot_circuit_maintenance": {
-            "nautobot_ver": "2.0.0-rc.2",
+            "nautobot_ver": "2.0.0-rc.3",
             "project_name": "nautobot_circuit_maintenance",
             "python_ver": "3.10",
             "local": False,


### PR DESCRIPTION
# Closes NaN

## What's Changed

- Aligned `next-2.0` with `develop`.
- Updated Nautobot version to `2.0.0rc3` in Docker compose environment.
