### PR TITLE
Fix test in next-2.0

### DIFF
--- a/nautobot_circuit_maintenance/filters.py
+++ b/nautobot_circuit_maintenance/filters.py
@@ -46,7 +46,7 @@ class CircuitMaintenanceFilterSet(NautobotFilterSet):
         """Meta class attributes for CircuitMaintenanceFilterSet."""
 
         model = CircuitMaintenance
-        fields = ["name", "status", "ack"]
+        fields = ["id", "name", "status", "ack"]
 
     def search(self, queryset, name, value):  # pylint: disable=unused-argument, no-self-use
         """Perform the filtered search."""

--- a/nautobot_circuit_maintenance/tests/test_views.py
+++ b/nautobot_circuit_maintenance/tests/test_views.py
@@ -162,6 +162,7 @@ class CircuitImpactTest(ViewTestCases.OrganizationalObjectViewTestCase):
             (
                 CircuitImpact(maintenance=maintenances[0], circuit=circuits[0]),
                 CircuitImpact(maintenance=maintenances[1], circuit=circuits[0]),
+                CircuitImpact(maintenance=maintenances[1], circuit=circuits[-1]),
             )
         )
 

--- a/nautobot_circuit_maintenance/tests/test_views.py
+++ b/nautobot_circuit_maintenance/tests/test_views.py
@@ -230,6 +230,7 @@ class NoteTest(ViewTestCases.OrganizationalObjectViewTestCase):
             name="UT-TEST-1", start_time="2020-10-04 10:00:00Z", end_time="2020-10-04 12:00:00Z"
         )
 
+        Note.objects.create(maintenance=maintenance, title="Note 0", comment="comment 0")
         Note.objects.create(maintenance=maintenance, title="Note 1", comment="comment 1")
         Note.objects.create(maintenance=maintenance, title="Note 2", comment="comment 2")
 
@@ -391,6 +392,14 @@ class RawNotificationTest(
             sender="whatever",
             source=source,
             raw=b"whatever 1",
+            stamp=datetime.now(timezone.utc),
+        )
+
+        RawNotification.objects.create(
+            subject="whatever",
+            provider=providers[1],
+            source=source,
+            raw=b"whatever 2",
             stamp=datetime.now(timezone.utc),
         )
 

--- a/nautobot_circuit_maintenance/views.py
+++ b/nautobot_circuit_maintenance/views.py
@@ -247,6 +247,7 @@ class CircuitMaintenanceBulkEditView(generic.BulkEditView):
     """View for bulk editing circuitmaintenance features."""
 
     queryset = models.CircuitMaintenance.objects.all()
+    filterset = filters.CircuitMaintenanceFilterSet
     table = tables.CircuitMaintenanceTable
     form = forms.CircuitMaintenanceBulkEditForm
 
@@ -255,6 +256,7 @@ class CircuitMaintenanceBulkDeleteView(generic.BulkDeleteView):
     """View for bulk deleting circuitmaintenance features."""
 
     queryset = models.CircuitMaintenance.objects.all()
+    filterset = filters.CircuitMaintenanceFilterSet
     table = tables.CircuitMaintenanceTable
 
 
@@ -322,6 +324,7 @@ class CircuitImpactBulkDeleteView(generic.BulkDeleteView):
     """View for bulk deleting circuit impact features."""
 
     queryset = models.CircuitImpact.objects.all()
+    filterset = filters.CircuitImpactFilterSet
     table = tables.CircuitImpactTable
 
 
@@ -372,6 +375,7 @@ class NoteBulkDeleteView(generic.BulkDeleteView):
     """View for bulk deleting Notea."""
 
     queryset = models.Note.objects.all()
+    filterset = filters.NoteFilterSet
     table = tables.NoteTable
 
 
@@ -412,6 +416,7 @@ class RawNotificationBulkDeleteView(generic.BulkDeleteView):
     """View for bulk deleting Circuit Maintenance Notifications entries."""
 
     queryset = models.RawNotification.objects.all()
+    filterset = filters.RawNotificationFilterSet
     table = tables.RawNotificationTable
 
 

--- a/nautobot_circuit_maintenance/views.py
+++ b/nautobot_circuit_maintenance/views.py
@@ -372,7 +372,7 @@ class NoteBulkEditView(generic.BulkEditView):
 
 
 class NoteBulkDeleteView(generic.BulkDeleteView):
-    """View for bulk deleting Notea."""
+    """View for bulk deleting Notes."""
 
     queryset = models.Note.objects.all()
     filterset = filters.NoteFilterSet

--- a/tasks.py
+++ b/tasks.py
@@ -46,7 +46,7 @@ namespace = Collection("nautobot_circuit_maintenance")
 namespace.configure(
     {
         "nautobot_circuit_maintenance": {
-            "nautobot_ver": "2.0.0-rc.3",
+            "nautobot_ver": "2.0.0-rc.4",
             "project_name": "nautobot_circuit_maintenance",
             "python_ver": "3.10",
             "local": False,


### PR DESCRIPTION
2.0 recently (https://github.com/nautobot/nautobot/pull/4443) added a test case to the generic API that expects three object instances to be present, but this test was only creating two instances. We should fix the test to fail more gracefully when that is the case, but the changes here should get tests back to passing for this app.

(edit) After fixing the number of test objects, this test case uncovered a legitimate issue in this app that several bulk-operation views were also missing filterset declarations.