### PR TITLE
Release v2.4.0

### DIFF
--- a/changes/+nautobot-app-v2-4-1.housekeeping
+++ b/changes/+nautobot-app-v2-4-1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.4.1`.

--- a/changes/+nautobot-app-v2-4-2.housekeeping
+++ b/changes/+nautobot-app-v2-4-2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.4.2`.

--- a/changes/+nautobot-app-v2.5.0.housekeeping
+++ b/changes/+nautobot-app-v2.5.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.0`.

--- a/changes/+nautobot-app-v2.5.1.housekeeping
+++ b/changes/+nautobot-app-v2.5.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.5.1`.

--- a/changes/+nautobot-app-v2.6.0.housekeeping
+++ b/changes/+nautobot-app-v2.6.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.6.0`.

--- a/changes/+nautobot-app-v2.7.0.housekeeping
+++ b/changes/+nautobot-app-v2.7.0.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.0`.

--- a/changes/+nautobot-app-v2.7.1.housekeeping
+++ b/changes/+nautobot-app-v2.7.1.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.1`.

--- a/changes/+nautobot-app-v2.7.2.housekeeping
+++ b/changes/+nautobot-app-v2.7.2.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/changes/336.security
+++ b/changes/336.security
@@ -1,2 +1,0 @@
-Removed the password and credentials from the serialization of the Source object.
-Simplified the log message for a notification to only relevant data.

--- a/changes/340.dependencies
+++ b/changes/340.dependencies
@@ -1,1 +1,0 @@
-Pinned Django debug toolbar to <6.0.0.

--- a/changes/341.housekeeping
+++ b/changes/341.housekeeping
@@ -1,1 +1,0 @@
-Updated codeowners.

--- a/changes/344.housekeeping
+++ b/changes/344.housekeeping
@@ -1,1 +1,0 @@
-Refactored CircuitMaintenance, CircuitImpact, Note, NotificationSource model related UI views to use `NautobotUIViewSet`.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -1,0 +1,33 @@
+# v2.4 Release Notes
+
+This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Release Overview
+
+- Fixed a potential sensitive data disclosure issue in the REST API and logging in the "Update Circuit Maintenances" job.
+- Changed minimum Nautobot version to 2.4.20.
+- Dropped support for Python versions 3.8 and 3.9.
+
+<!-- towncrier release notes start -->
+## [v2.4.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-circuit-maintenance/releases/tag/v2.4.0)
+
+### Security
+
+- [#336](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/336) - Removed the password and credentials from the serialization of the Source object.
+- [#336](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/336) - Updated logging messages to prevent logging sensitive data from the Source object.
+
+### Dependencies
+
+- [#340](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/340) - Pinned Django debug toolbar to <6.0.0.
+
+### Housekeeping
+
+- [#344](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/344) - Refactored CircuitMaintenance, CircuitImpact, Note, NotificationSource model related UI views to use `NautobotUIViewSet`.
+- Rebaked from the cookie `nautobot-app-v2.4.1`.
+- Rebaked from the cookie `nautobot-app-v2.4.2`.
+- Rebaked from the cookie `nautobot-app-v2.5.0`.
+- Rebaked from the cookie `nautobot-app-v2.5.1`.
+- Rebaked from the cookie `nautobot-app-v2.6.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.0`.
+- Rebaked from the cookie `nautobot-app-v2.7.1`.
+- Rebaked from the cookie `nautobot-app-v2.7.2`.

--- a/docs/admin/release_notes/version_2.4.md
+++ b/docs/admin/release_notes/version_2.4.md
@@ -9,7 +9,7 @@ This document describes all new features and changes in the release. The format 
 - Dropped support for Python versions 3.8 and 3.9.
 
 <!-- towncrier release notes start -->
-## [v2.4.0 (2025-12-05)](https://github.com/nautobot/nautobot-app-circuit-maintenance/releases/tag/v2.4.0)
+## [v2.4.0 (2025-12-09)](https://github.com/nautobot/nautobot-app-circuit-maintenance/releases/tag/v2.4.0)
 
 ### Security
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -118,6 +118,7 @@ nav:
       - Compatibility Matrix: "admin/compatibility_matrix.md"
       - Release Notes:
           - "admin/release_notes/index.md"
+          - v2.4: "admin/release_notes/version_2.4.md"
           - v2.3: "admin/release_notes/version_2.3.md"
           - v2.2: "admin/release_notes/version_2.2.md"
           - v2.1: "admin/release_notes/version_2.1.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-circuit-maintenance"
-version = "2.4.0a0"
+version = "2.4.0"
 description = "Nautobot app to automatically handle Circuit Maintenances Notifications"
 authors = ["Network to Code, LLC <opensource@networktocode.com>"]
 license = "Apache-2.0"
@@ -183,7 +183,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_circuit_maintenance"
 directory = "changes"
-filename = "docs/admin/release_notes/version_2.3.md"
+filename = "docs/admin/release_notes/version_2.4.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/{issue})"


### PR DESCRIPTION
# v2.4 Release Notes

This document describes all new features and changes in the release. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## Release Overview

- Fixed a potential sensitive data disclosure issue in the REST API and logging in the "Update Circuit Maintenances" job.
- Changed minimum Nautobot version to 2.4.20.
- Dropped support for Python versions 3.8 and 3.9.

## [v2.4.0 (2025-12-09)](https://github.com/nautobot/nautobot-app-circuit-maintenance/releases/tag/v2.4.0)

### Security

- [#336](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/336) - Removed the password and credentials from the serialization of the Source object.
- [#336](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/336) - Updated logging messages to prevent logging sensitive data from the Source object.

### Dependencies

- [#340](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/340) - Pinned Django debug toolbar to <6.0.0.

### Housekeeping

- [#344](https://github.com/nautobot/nautobot-app-circuit-maintenance/issues/344) - Refactored CircuitMaintenance, CircuitImpact, Note, NotificationSource model related UI views to use `NautobotUIViewSet`.
- Rebaked from the cookie `nautobot-app-v2.4.1`.
- Rebaked from the cookie `nautobot-app-v2.4.2`.
- Rebaked from the cookie `nautobot-app-v2.5.0`.
- Rebaked from the cookie `nautobot-app-v2.5.1`.
- Rebaked from the cookie `nautobot-app-v2.6.0`.
- Rebaked from the cookie `nautobot-app-v2.7.0`.
- Rebaked from the cookie `nautobot-app-v2.7.1`.
- Rebaked from the cookie `nautobot-app-v2.7.2`.
