### PR TITLE
Rename Circuit Maintenance navigation menu group and list item

### DIFF
--- a/changes/389.changed
+++ b/changes/389.changed
@@ -1,0 +1,1 @@
+Renamed the navigation menu group from "Circuit Maintenance App" to "Circuit Maintenances" and the maintenance list menu item to "Maintenances".

--- a/nautobot_circuit_maintenance/navigation.py
+++ b/nautobot_circuit_maintenance/navigation.py
@@ -15,7 +15,7 @@ menu_items = (
         weight=NavigationWeightChoices.CIRCUITS,
         groups=(
             NavMenuGroup(
-                name="Circuit Maintenance App",
+                name="Circuit Maintenances",
                 weight=250,
                 items=(
                     NavMenuItem(
@@ -26,7 +26,7 @@ menu_items = (
                     ),
                     NavMenuItem(
                         link="plugins:nautobot_circuit_maintenance:circuitmaintenance_list",
-                        name="Circuit Maintenances",
+                        name="Maintenances",
                         weight=200,
                         permissions=["nautobot_circuit_maintenance.view_circuitmaintenance"],
                     ),

--- a/nautobot_circuit_maintenance/tests/test_navigation.py
+++ b/nautobot_circuit_maintenance/tests/test_navigation.py
@@ -1,0 +1,82 @@
+"""Tests for the Circuit Maintenance navigation menu."""
+
+from django.urls import reverse
+from nautobot.apps.testing import TestCase
+from nautobot.apps.ui import NavigationIconChoices, NavigationWeightChoices
+
+from nautobot_circuit_maintenance.navigation import menu_items
+
+
+class NavigationMenuTestCase(TestCase):
+    """Test the Circuit Maintenance navigation menu structure."""
+
+    @classmethod
+    def setUpTestData(cls):
+        """Resolve the Circuits tab and its Circuit Maintenance group once for all tests."""
+        cls.tab = next(tab for tab in menu_items if tab.name == "Circuits")
+        cls.group = next(group for group in cls.tab.groups if group.name == "Circuit Maintenances")
+
+    def test_single_tab(self):
+        """The app contributes exactly one navigation tab: 'Circuits'."""
+        self.assertEqual(len(menu_items), 1)
+        self.assertEqual(menu_items[0].name, "Circuits")
+
+    def test_tab_attributes(self):
+        """The Circuits tab uses the standard Circuits icon and weight."""
+        self.assertEqual(self.tab.icon, NavigationIconChoices.CIRCUITS)
+        self.assertEqual(self.tab.weight, NavigationWeightChoices.CIRCUITS)
+
+    def test_menu_group_name(self):
+        """The navigation menu group is named 'Circuit Maintenances', not 'Circuit Maintenance App'."""
+        group_names = [group.name for group in self.tab.groups]
+        self.assertIn("Circuit Maintenances", group_names)
+        self.assertNotIn("Circuit Maintenance App", group_names)
+
+    def test_group_attributes(self):
+        """The Circuit Maintenances group has the expected weight."""
+        self.assertEqual(self.group.weight, 250)
+
+    def test_menu_items(self):
+        """The group exposes the expected items, in order, with correct links, weights, and permissions."""
+        expected_items = [
+            {
+                "link": "plugins:nautobot_circuit_maintenance:circuitmaintenance_overview",
+                "name": "Dashboard",
+                "weight": 100,
+                "permissions": {"nautobot_circuit_maintenance.view_circuitmaintenance"},
+            },
+            {
+                "link": "plugins:nautobot_circuit_maintenance:circuitmaintenance_list",
+                "name": "Maintenances",
+                "weight": 200,
+                "permissions": {"nautobot_circuit_maintenance.view_circuitmaintenance"},
+            },
+            {
+                "link": "plugins:nautobot_circuit_maintenance:rawnotification_list",
+                "name": "Notifications",
+                "weight": 300,
+                "permissions": {"nautobot_circuit_maintenance.view_circuitmaintenance"},
+            },
+            {
+                "link": "plugins:nautobot_circuit_maintenance:notificationsource_list",
+                "name": "Notification Sources",
+                "weight": 400,
+                "permissions": {"nautobot_circuit_maintenance.view_notificationsource"},
+            },
+        ]
+
+        self.assertEqual(len(self.group.items), len(expected_items))
+        for item, expected in zip(self.group.items, expected_items):
+            with self.subTest(item=expected["name"]):
+                # Nautobot resolves NavMenuItem.link to a URL path at app-load time,
+                # so compare against the reversed route rather than the raw route name.
+                self.assertEqual(item.link, reverse(expected["link"]))
+                self.assertEqual(item.name, expected["name"])
+                self.assertEqual(item.weight, expected["weight"])
+                self.assertEqual(item.permissions, expected["permissions"])
+
+    def test_maintenances_item_renamed(self):
+        """The circuit maintenance list item is named 'Maintenances', not 'Circuit Maintenances'."""
+        item_names = [item.name for item in self.group.items]
+        self.assertIn("Maintenances", item_names)
+        self.assertNotIn("Circuit Maintenances", item_names)


### PR DESCRIPTION
# Closes: #389

## What's Changed

Renames the app's navigation entries under the **Circuits** tab so they describe the
objects they expose rather than the plugin itself, matching Nautobot's navigation
conventions:

- **Menu group:** `Circuit Maintenance App` → `Circuit Maintenances`
- **List menu item:** `Circuit Maintenances` → `Maintenances`

Renaming the list item alongside the group also removes the redundancy that would
otherwise result in a group header and child item reading identically.

No functional changes — links, weights, and permissions are unchanged.

### Screenshots

| Before | After |
|--------|-------|
| _drop before image here_ | _drop after image here_ |

### Tests

Adds `tests/test_navigation.py`, which characterizes the full navigation structure
(tab, group, and every item's link/name/weight/permissions) and guards against
regression of both old names.

## To Do

- [x] Explanation of Change(s)
- [x] Added change log fragment(s)
- [x] Attached Screenshots, Payload Example
- [x] Unit, Integration Tests
- [x] Documentation Updates (when adding/changing features)
- [x] Outline Remaining Work, Constraints from Design

## Images
### Before

<img width="500" height="470" alt="circuit_maintenance_nav_before" src="https://github.com/user-attachments/assets/186e2498-7dbc-4cad-b794-dca6365dc5fc" />


### After
<img width="500" height="470" alt="circuit_maintenance_nav_after" src="https://github.com/user-attachments/assets/28560623-1214-456a-bea9-10f44e035f56" />
