### PR TITLE
Add configurable lookback window to the Handle Notifications job (#170)

### DIFF
--- a/changes/170.added
+++ b/changes/170.added
@@ -1,0 +1,1 @@
+Added optional lookback window inputs (days to look back, fetch since) to the Handle Notifications job for re-fetching older notifications on demand.

--- a/docs/user/app_use_cases.md
+++ b/docs/user/app_use_cases.md
@@ -217,7 +217,21 @@ PLUGINS_CONFIG = {
 
 There is an asynchronous task defined as a **Nautobot Job**, **Handle Circuit Maintenance Notifications** that will connect to the email sources defined under the Notification Sources section (step above), and will fetch new notifications received since the last notification was fetched.
 
+By default the job runs **incrementally**: it only fetches notifications newer than the most recent `RawNotification` already stored. On the very first run (when no notifications exist yet) it looks back `raw_notification_initial_days_since` days instead (7 by default, see [the install guide](../admin/install.md)).
+
 Each notification will be parsed using the [circuit-maintenance-parser](https://github.com/networktocode/circuit-maintenance-parser) library, and if a valid parsing is executed, a new **Circuit Maintenance** will be created, or if it was already created, it will updated with the new data.
+
+#### Re-fetching older notifications (lookback window)
+
+The job exposes two optional inputs that override the normal incremental window when you need to pull in older notifications, for example to import notices that predate your first run:
+
+- **Days to look back** — an integer `N`; fetch notifications from the last `N` days (`now - N days`).
+- **Fetch notifications since** — an ISO 8601 date/time (for example `2026-01-31` or `2026-01-31T00:00:00Z`); fetch notifications with a timestamp on or after that instant. Assumed UTC when no timezone is given.
+
+Either input replaces the normal watermark. If you set both, the job uses the **earlier** of the two start times, so together they mean "look back at least this far." Leave both blank for normal incremental processing.
+
+!!! note "Re-processing already-stored notifications"
+    A lookback window widens the range of notifications the job *fetches*, but Nautobot deduplicates `RawNotification` records by subject, provider, and timestamp. A notification that was already fetched is therefore skipped even when it falls inside the lookback window. To **re-parse** notifications that were stored but failed to parse (for instance after upgrading `circuit-maintenance-parser`), delete their `RawNotification` records first, then run the job with a lookback window that covers them.
 
 So, for each email notification received, several objects will be created:
 

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -392,11 +392,11 @@ def get_since_reference(
 
     overrides = []
     if days_to_look_back:
-        overrides.append(int((now - datetime.timedelta(days=days_to_look_back)).timestamp()))
+        overrides.append(now - datetime.timedelta(days=days_to_look_back))
     if fetch_since:
-        overrides.append(int(fetch_since.timestamp()))
+        overrides.append(fetch_since)
     if overrides:
-        since_reference = min(overrides)
+        since_reference = int(min(overrides).timestamp())
         job.logger.info(f"Processing notifications since {since_reference} (manual lookback override).")
         return since_reference
 
@@ -456,8 +456,9 @@ class HandleCircuitMaintenanceNotifications(Job):
             try:
                 fetch_since_dt = parser.parse(fetch_since)
             except (ValueError, OverflowError) as error:
-                self.logger.error(f"Invalid 'Fetch notifications since' value '{fetch_since}': {error}")
-                return []
+                raise ValueError(
+                    f"Invalid 'Fetch notifications since' value '{fetch_since}'. Provide an ISO 8601 date/time."
+                ) from error
             if fetch_since_dt.tzinfo is None:
                 fetch_since_dt = fetch_since_dt.replace(tzinfo=datetime.timezone.utc)
 

--- a/nautobot_circuit_maintenance/handle_notifications/handler.py
+++ b/nautobot_circuit_maintenance/handle_notifications/handler.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 from nautobot.circuits.models import Circuit, Provider
-from nautobot.extras.jobs import DryRunVar, Job
+from nautobot.extras.jobs import DryRunVar, IntegerVar, Job, StringVar
 
 from nautobot_circuit_maintenance.choices import CircuitMaintenanceStatusChoices
 from nautobot_circuit_maintenance.enum import MessageProcessingStatus
@@ -373,17 +373,41 @@ def process_raw_notification(job: Job, notification: MaintenanceNotification) ->
     return raw_entry.id
 
 
-def get_since_reference(job: Job) -> int:
-    """Get the timestamp from the latest processed RawNotification or a reference from config `raw_notification_initial_days_since`."""
+def get_since_reference(
+    job: Job,
+    days_to_look_back: Optional[int] = None,
+    fetch_since: Optional[datetime.datetime] = None,
+) -> int:
+    """Get the timestamp used to limit how far back notifications are retrieved.
+
+    When either `days_to_look_back` or `fetch_since` is provided, the value overrides the normal
+    incremental window: the earliest of the requested start times is used so the two together mean
+    "look back at least this far". This lets an operator re-fetch older notifications on demand.
+
+    Otherwise the normal incremental behavior applies: the timestamp of the latest processed
+    `RawNotification`, or, on the first run, `now` minus the configured
+    `raw_notification_initial_days_since`.
+    """
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    overrides = []
+    if days_to_look_back:
+        overrides.append(int((now - datetime.timedelta(days=days_to_look_back)).timestamp()))
+    if fetch_since:
+        overrides.append(int(fetch_since.timestamp()))
+    if overrides:
+        since_reference = min(overrides)
+        job.logger.info(f"Processing notifications since {since_reference} (manual lookback override).")
+        return since_reference
+
     # Latest retrieved notification will limit the scope of notifications to retrieve
     last_raw_notification = RawNotification.objects.last()
     if last_raw_notification:
-        since_reference = last_raw_notification.last_updated.timestamp()
+        since_reference = int(last_raw_notification.last_updated.timestamp())
     else:
-        since_reference = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(
-            days=PLUGIN_SETTINGS.get("raw_notification_initial_days_since")
+        since_reference = int(
+            (now - datetime.timedelta(days=PLUGIN_SETTINGS.get("raw_notification_initial_days_since"))).timestamp()
         )
-        since_reference = int(since_reference.timestamp())
     job.logger.info(f"Processing notifications since {since_reference}", extra={"object": last_raw_notification})
     return since_reference
 
@@ -396,6 +420,24 @@ class HandleCircuitMaintenanceNotifications(Job):
     """Job to handle external circuit maintenance notifications and turn them into Circuit Maintenances."""
 
     dryrun = DryRunVar()
+    days_to_look_back = IntegerVar(
+        required=False,
+        min_value=1,
+        label="Days to look back",
+        description=(
+            "Re-fetch notifications from the last N days, overriding the normal incremental window. "
+            "Leave blank for normal incremental processing."
+        ),
+    )
+    fetch_since = StringVar(
+        required=False,
+        label="Fetch notifications since",
+        description=(
+            "Fetch notifications with a timestamp on or after this date/time (ISO 8601, e.g. "
+            "2026-01-31 or 2026-01-31T00:00:00Z), overriding the normal incremental window. "
+            "Assumed UTC if no timezone is given. Leave blank for normal incremental processing."
+        ),
+    )
 
     class Meta:
         """Meta object boilerplate for HandleParsedNotifications."""
@@ -405,9 +447,19 @@ class HandleCircuitMaintenanceNotifications(Job):
         description = "Fetch Circuit Maintenance Notifications from Sources and create or update Circuit Maintenances accordingly."
 
     # pylint: disable=arguments-differ
-    def run(self, dryrun=False) -> List[uuid.UUID]:
+    def run(self, dryrun=False, days_to_look_back=None, fetch_since=None) -> List[uuid.UUID]:
         """Fetch notifications, process them and update Circuit Maintenance accordingly."""
         self.logger.debug("Starting Handle Notifications job.")
+
+        fetch_since_dt = None
+        if fetch_since:
+            try:
+                fetch_since_dt = parser.parse(fetch_since)
+            except (ValueError, OverflowError) as error:
+                self.logger.error(f"Invalid 'Fetch notifications since' value '{fetch_since}': {error}")
+                return []
+            if fetch_since_dt.tzinfo is None:
+                fetch_since_dt = fetch_since_dt.replace(tzinfo=datetime.timezone.utc)
 
         notification_sources = NotificationSource.objects.all()
         if not notification_sources:
@@ -418,7 +470,7 @@ class HandleCircuitMaintenanceNotifications(Job):
             notifications = get_notifications(
                 job=self,
                 notification_sources=notification_sources,
-                since=get_since_reference(self),
+                since=get_since_reference(self, days_to_look_back, fetch_since_dt),
             )
         except Exception:
             self.logger.error(

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -595,10 +595,10 @@ class TestHandleNotificationsJob(TestCase):  # pylint: disable=too-many-public-m
         since_reference = get_since_reference(self.job, days_to_look_back=1, fetch_since=fetch_since)
         self.assertEqual(since_reference, int(fetch_since.timestamp()))
 
-    def test_run_invalid_fetch_since_returns_empty(self):
-        """An unparseable `fetch_since` value fails fast without processing notifications."""
-        result = self.job.run(fetch_since="not-a-date")
-        self.assertEqual(result, [])
+    def test_run_invalid_fetch_since_raises(self):
+        """An unparseable `fetch_since` value fails the job loudly instead of silently doing nothing."""
+        with self.assertRaises(ValueError):
+            self.job.run(fetch_since="not-a-date")
 
     def test_update_circuit_maintenance_with_duplicated_notes(self):
         """Test update_circuit_maintenance with duplicated notes."""

--- a/nautobot_circuit_maintenance/tests/test_handler.py
+++ b/nautobot_circuit_maintenance/tests/test_handler.py
@@ -1,7 +1,7 @@
 """Tests for Handle Notifications methods."""
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from email.message import EmailMessage
 from email.utils import format_datetime
 from unittest.mock import ANY, Mock, patch
@@ -13,6 +13,7 @@ from jinja2 import Template
 from nautobot.circuits.models import Circuit, Provider
 
 from nautobot_circuit_maintenance.handle_notifications.handler import (
+    PLUGIN_SETTINGS,
     HandleCircuitMaintenanceNotifications,
     create_circuit_maintenance,
     get_maintenances_from_notification,
@@ -560,7 +561,44 @@ class TestHandleNotificationsJob(TestCase):  # pylint: disable=too-many-public-m
         test_notification = generate_email_notification(notification_data, self.source)
         raw_id = process_raw_notification(self.job, test_notification)
         since_reference = get_since_reference(self.job)
-        self.assertEqual(since_reference, RawNotification.objects.get(id=raw_id).last_updated.timestamp())
+        self.assertEqual(since_reference, int(RawNotification.objects.get(id=raw_id).last_updated.timestamp()))
+
+    def test_get_since_first_run_uses_configured_default(self):
+        """Without prior notifications or overrides, the initial-days-since default is used."""
+        expected = int(
+            (
+                datetime.now(timezone.utc) - timedelta(days=PLUGIN_SETTINGS["raw_notification_initial_days_since"])
+            ).timestamp()
+        )
+        since_reference = get_since_reference(self.job)
+        # Allow a small delta for the seconds elapsed during the test run.
+        self.assertAlmostEqual(since_reference, expected, delta=30)
+
+    def test_get_since_days_to_look_back_override(self):
+        """`days_to_look_back` overrides the watermark with `now - N days`, ignoring prior notifications."""
+        process_raw_notification(self.job, generate_email_notification(get_base_notification_data(), self.source))
+        expected = int((datetime.now(timezone.utc) - timedelta(days=45)).timestamp())
+        since_reference = get_since_reference(self.job, days_to_look_back=45)
+        self.assertAlmostEqual(since_reference, expected, delta=30)
+
+    def test_get_since_fetch_since_override(self):
+        """`fetch_since` overrides the watermark with the supplied datetime."""
+        process_raw_notification(self.job, generate_email_notification(get_base_notification_data(), self.source))
+        fetch_since = datetime(2021, 1, 1, tzinfo=timezone.utc)
+        since_reference = get_since_reference(self.job, fetch_since=fetch_since)
+        self.assertEqual(since_reference, int(fetch_since.timestamp()))
+
+    def test_get_since_both_overrides_use_earliest(self):
+        """When both overrides are set, the earliest (furthest-back) start time wins."""
+        fetch_since = datetime(2021, 1, 1, tzinfo=timezone.utc)  # far in the past
+        # days_to_look_back=1 is much more recent than 2021, so fetch_since should win.
+        since_reference = get_since_reference(self.job, days_to_look_back=1, fetch_since=fetch_since)
+        self.assertEqual(since_reference, int(fetch_since.timestamp()))
+
+    def test_run_invalid_fetch_since_returns_empty(self):
+        """An unparseable `fetch_since` value fails fast without processing notifications."""
+        result = self.job.run(fetch_since="not-a-date")
+        self.assertEqual(result, [])
 
     def test_update_circuit_maintenance_with_duplicated_notes(self):
         """Test update_circuit_maintenance with duplicated notes."""


### PR DESCRIPTION
## Closes: #170

## What's Changed

Adds two optional inputs to the **Update Circuit Maintenances** job so operators can re-fetch older notifications on demand, instead of always being limited to the normal incremental window (the timestamp of the last stored notification, or `raw_notification_initial_days_since` on the first run).

- **Days to look back** (`IntegerVar`) — fetch notifications from the last `N` days (`now - N days`).
- **Fetch notifications since** (`StringVar`, ISO 8601 date/time, e.g. `2026-01-31` or `2026-01-31T00:00:00Z`) — fetch notifications on or after that instant; assumed UTC when no timezone is given.

Either input overrides the normal watermark. When both are set, the **earliest** start time wins ("look back at least this far"). Leave both blank for normal incremental processing. An unparseable `Fetch notifications since` value fails the job with a clear error rather than silently doing nothing.

> **Note:** Nautobot's job framework has no `DateTimeVar` (vars are String/Text/Integer/Boolean/Choice/Object/File/IP/JSON), so the absolute datetime input is a `StringVar` parsed with `dateutil` and normalized to UTC.

### Re-processing already-stored notifications

A lookback window widens the range of notifications the job *fetches*, but `RawNotification` records are deduplicated by `(subject, provider, stamp)`, so an already-stored notification is skipped even inside the window. To **re-parse** notifications that were stored but failed to parse (e.g. after upgrading `circuit-maintenance-parser`), delete their `RawNotification` records first, then run the job with a lookback that covers them. This is documented in the user guide.

## Screenshots

Not applicable — this adds standard Nautobot-rendered inputs to an existing Job form (no custom UI).

## Testing

- Added tests for `get_since_reference` (days override, datetime override, both → earliest, first-run default) and for the job failing on an invalid `fetch_since` value; updated the existing watermark test for the `int` return type.
- `test_handler` (28) and `test_jobs` (4) pass; `ruff` lint + format clean; docs build (mkdocs strict) passes; no missing migrations.

## Docs

- `docs/user/app_use_cases.md` — new "Re-fetching older notifications (lookback window)" section documenting both inputs and the delete-then-reprocess workflow.
