### PR TITLE
Fix Notification Source edit form base class and Provider widget (#332)

### DIFF
--- a/changes/332.fixed
+++ b/changes/332.fixed
@@ -1,0 +1,1 @@
+Fixed the Notification Source edit form omitting custom fields and rendering Providers without a searchable selector.

--- a/nautobot_circuit_maintenance/forms.py
+++ b/nautobot_circuit_maintenance/forms.py
@@ -172,14 +172,19 @@ class RawNotificationFilterForm(NautobotFilterForm):
     since = forms.DateTimeField(required=False, widget=DateTimePicker())
 
 
-class NotificationSourceForm(BootstrapMixin, forms.ModelForm):
+class NotificationSourceForm(NautobotModelForm):
     """Form for creating new NotificationSource."""
+
+    providers = DynamicModelMultipleChoiceField(queryset=Provider.objects.all(), required=False)
 
     class Meta:  # noqa: D106 "Missing docstring in public nested class"
         """Metaclass attributes for NotificationSourceForm."""
 
         model = NotificationSource
-        fields = ["providers"]
+        # `name` and `attach_all_providers` are owned by PLUGINS_CONFIG and re-applied on every
+        # post_migrate by import_notification_sources(), which also deletes any Notification Source
+        # whose name is absent from the config. `providers` is the only safely user-editable field.
+        fields = ["providers"]  # pylint:disable=nb-use-fields-all
 
 
 class NotificationSourceBulkEditForm(NautobotBulkEditForm, TagsBulkEditFormMixin):

--- a/nautobot_circuit_maintenance/tests/test_forms.py
+++ b/nautobot_circuit_maintenance/tests/test_forms.py
@@ -1,0 +1,31 @@
+"""Test for Circuit Maintenance Forms."""
+
+from django.contrib.contenttypes.models import ContentType
+from nautobot.apps.forms import DynamicModelMultipleChoiceField
+from nautobot.apps.testing import FormTestCases
+from nautobot.extras.choices import CustomFieldTypeChoices
+from nautobot.extras.models import CustomField
+
+from nautobot_circuit_maintenance.forms import NotificationSourceForm
+from nautobot_circuit_maintenance.models import NotificationSource
+
+
+class NotificationSourceFormTestCase(FormTestCases.BaseFormTestCase):
+    """Tests for NotificationSourceForm."""
+
+    form_class = NotificationSourceForm
+
+    def test_providers_uses_api_backed_multi_select(self):
+        """The providers field should be API-backed so the edit form stays usable with many Providers."""
+        self.assertIsInstance(NotificationSourceForm().fields["providers"], DynamicModelMultipleChoiceField)
+
+    def test_custom_fields_are_editable(self):
+        """Custom fields defined on NotificationSource should be editable on the form."""
+        custom_field = CustomField.objects.create(
+            type=CustomFieldTypeChoices.TYPE_TEXT,
+            key="notification_source_test_field",
+            label="Notification Source Test Field",
+        )
+        custom_field.content_types.set([ContentType.objects.get_for_model(NotificationSource)])
+
+        self.assertIn(custom_field.add_prefix_to_cf_key(), NotificationSourceForm().fields)


### PR DESCRIPTION
Closes #332.

## Problem

`NotificationSourceForm` subclassed `django.forms.ModelForm` rather than `NautobotModelForm`, so none of the Nautobot form mixins applied. Two user-visible consequences:

- **Custom fields were silently omitted.** `NotificationSource` is an `OrganizationalModel`, which includes `CustomFieldModel` — so custom fields can be defined on it — but `CustomFieldModelFormMixin` only arrives via `NautobotModelForm`. The edit form rendered a single field regardless of any custom fields configured.
- **Providers had no search.** The auto-generated `ModelMultipleChoiceField` rendered every `Provider` as an `<option>` on each edit page load, instead of the API-backed selector used elsewhere in the app.

The viewset half of #332 was already resolved by #344; this is the remaining form half that @gsnider2195 called out in the issue ("wrong base class", "wrong widget for `providers` field").

## Change

```python
class NotificationSourceForm(NautobotModelForm):
    providers = DynamicModelMultipleChoiceField(queryset=Provider.objects.all(), required=False)
```

This matches `CircuitImpactForm`, `CircuitMaintenanceForm`, and `NoteForm` in the same module; both imports were already present.

`required=False` is required, not incidental — an explicitly declared form field bypasses `fields_for_model`, so the model's `blank=True` does not propagate and Providers would otherwise become mandatory.

## Why `fields` stays an explicit list

Switching to `NautobotModelForm` activates the `nb-use-fields-all` pylint check, which asks for `fields = "__all__"`. Following that here would be a bug, so the rule is suppressed with the rationale recorded inline.

`name` and `attach_all_providers` are owned by `PLUGINS_CONFIG`: `import_notification_sources()` runs on every `post_migrate`, re-applies `attach_all_providers` from config, and **deletes** any Notification Source whose name is absent from the config. Exposing `name` in the UI would let a rename silently delete the object on the next migrate. This matches the documented behavior in `docs/user/app_getting_started.md` — "you can only view and edit `providers`". `providers` is the only safely user-editable field.

## Testing

Adds `nautobot_circuit_maintenance/tests/test_forms.py`, written test-first — both tests were confirmed failing against the old form before the fix (`'cf_…' not found in {'providers': ModelMultipleChoiceField}` and `ModelMultipleChoiceField is not an instance of DynamicModelMultipleChoiceField`).

It extends `FormTestCases.BaseFormTestCase`, which also contributes a `query_params` validation guard for any `DynamicModelChoice` field added later.

- `invoke unittest --label nautobot_circuit_maintenance.tests.test_forms` → 3 tests OK (1 inherited test skips: `providers` declares no `query_params`).
- Full suite → 296/297. The one failure is `test_basics.TestVersion` (`'3.0.1a0' != '3.1.2a0'`), which reproduces identically on a pristine `develop` checkout — a stale app version in the local container image, unrelated to this change.
- `invoke pylint` → 10.00/10; `ruff check` / `ruff format --check` clean.

## Follow-up (not in this PR)

`NotificationSourceFilterSetForm` (same module, wired as `filterset_form_class` on the same viewset) is still on `BootstrapMixin, forms.ModelForm` and should be a `NautobotFilterForm`. It also exposes only `q`, while `NotificationSourceFilterSet` supports filtering on `name`, `providers`, `attach_all_providers`, `tags`, and `created` — so the list view cannot filter by Provider today. That is a behavior change rather than a bug fix, so it is left out of this PR; happy to open a separate issue. It is also the last class keeping the file-level `nb-incorrect-base-class` suppression alive.
