### PR TITLE
Address review follow-ups on the UIComponent refactor (#350)

### DIFF
--- a/nautobot_circuit_maintenance/tests/test_views.py
+++ b/nautobot_circuit_maintenance/tests/test_views.py
@@ -8,12 +8,14 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages import get_messages
 from django.urls import reverse
 from nautobot.circuits.models import Circuit, CircuitType, Provider
 from nautobot.core.testing import ModelViewTestCase, ViewTestCases
 from nautobot.extras.models import Status
 from nautobot.users.models import ObjectPermission
 
+from nautobot_circuit_maintenance.handle_notifications.sources import RedirectAuthorize
 from nautobot_circuit_maintenance.models import (
     CircuitImpact,
     CircuitMaintenance,
@@ -311,16 +313,19 @@ class NotificationSourceTest(
         settings.PLUGINS_CONFIG = {"nautobot_circuit_maintenance": {"notification_sources": [cls.SOURCE_1.copy()]}}
         NotificationSource.objects.create(name=cls.SOURCE_1["name"])
 
-    @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.test_authentication")
-    def test_validate_view_ok(self, mock_test_authentication):
-        """Test for custom NotificationSourceValidate view."""
-        mock_test_authentication.return_value = True, "Test OK"
-
-        # Adding test to user to run Validate
+    def _grant_view_permission(self):
+        """Give the test user permission to view NotificationSource so the Validate action is reachable."""
         obj_perm = ObjectPermission(name="Test permission", actions=["view"])
         obj_perm.save()
         obj_perm.users.add(self.user)
         obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+
+    @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.test_authentication")
+    def test_validate_view_ok(self, mock_test_authentication):
+        """A successful validation redirects to the detail view with a success message."""
+        mock_test_authentication.return_value = True, "Test OK"
+
+        self._grant_view_permission()
         source = NotificationSource.objects.get(name=self.SOURCE_1["name"])
         response = self.client.get(
             reverse(
@@ -328,27 +333,45 @@ class NotificationSourceTest(
                 kwargs={"pk": source.pk},
             )
         )
-        self.assertContains(response, "SUCCESS: Test OK", status_code=200)
+        self.assertRedirects(response, source.get_absolute_url(), fetch_redirect_response=False)
+        self.assertIn("SUCCESS: Test OK", [str(message) for message in get_messages(response.wsgi_request)])
 
     @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.test_authentication")
     def test_validate_view_ko(self, mock_test_authentication):
-        """Test for custom NotificationSourceValidate view."""
+        """A failed validation redirects to the detail view with an error message."""
         mock_test_authentication.return_value = False, "Some error"
 
-        # Adding test to user to run Validate
-        obj_perm = ObjectPermission(name="Test permission", actions=["view"])
-        obj_perm.save()
-        obj_perm.users.add(self.user)
-        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
+        self._grant_view_permission()
         source = NotificationSource.objects.get(name=self.SOURCE_1["name"])
-
         response = self.client.get(
             reverse(
                 "plugins:nautobot_circuit_maintenance:notificationsource_validate",
                 kwargs={"pk": source.pk},
             )
         )
-        self.assertContains(response, "FAILED: Some error", status_code=200)
+        self.assertRedirects(response, source.get_absolute_url(), fetch_redirect_response=False)
+        self.assertIn("FAILED: Some error", [str(message) for message in get_messages(response.wsgi_request)])
+
+    @patch("nautobot_circuit_maintenance.handle_notifications.sources.IMAP.test_authentication")
+    def test_validate_view_redirect_authorize(self, mock_test_authentication):
+        """A source needing (re)authorization redirects to the OAuth flow instead of raising (regression for #350)."""
+        mock_test_authentication.side_effect = RedirectAuthorize(
+            url_name="google_authorize", source_name=self.SOURCE_1["name"]
+        )
+
+        self._grant_view_permission()
+        source = NotificationSource.objects.get(name=self.SOURCE_1["name"])
+        response = self.client.get(
+            reverse(
+                "plugins:nautobot_circuit_maintenance:notificationsource_validate",
+                kwargs={"pk": source.pk},
+            )
+        )
+        expected_url = reverse(
+            "plugins:nautobot_circuit_maintenance:google_authorize",
+            kwargs={"name": self.SOURCE_1["name"]},
+        )
+        self.assertRedirects(response, expected_url, fetch_redirect_response=False)
 
     def test_list_objects_with_constrained_permission(self):
         """TODO: fix because it's checking the get_absolute_url() in a wrong page."""

--- a/nautobot_circuit_maintenance/views.py
+++ b/nautobot_circuit_maintenance/views.py
@@ -5,8 +5,10 @@ import logging
 
 import google_auth_oauthlib
 from django.conf import settings
-from django.shortcuts import redirect, render
+from django.contrib import messages
+from django.shortcuts import redirect
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 from django.utils.html import format_html, format_html_join
 from nautobot.apps.ui import Button
 from nautobot.apps.views import (
@@ -27,13 +29,11 @@ from nautobot.core.ui.object_detail import (
     ObjectFieldsPanel,
     ObjectsTablePanel,
 )
-from nautobot.core.views.utils import get_obj_from_context
-from nautobot.extras.tables import ContactAssociationTable, DynamicGroupTable, ObjectMetadataTable
 from rest_framework.decorators import action
 
 from nautobot_circuit_maintenance import filters, forms, models, tables
 from nautobot_circuit_maintenance.api import serializers
-from nautobot_circuit_maintenance.handle_notifications.sources import Source
+from nautobot_circuit_maintenance.handle_notifications.sources import RedirectAuthorize, Source
 
 logger = logging.getLogger(__name__)
 
@@ -209,26 +209,6 @@ class CircuitMaintenanceOverview(ObjectListView):  # pylint: disable=too-many-lo
         return self.queryset.count() / delta_months
 
 
-class CustomMaintenanceFieldsPanel(ObjectFieldsPanel):
-    """Panel to display maintenance details including notification provider."""
-
-    def get_data(self, context):
-        """Populate panel data with the notification provider if available."""
-        data = super().get_data(context)
-        instance = get_obj_from_context(context, self.context_object_key)
-        notification_provider = None
-        notification = getattr(instance, "parsednotification_set", None)
-        if notification:
-            first_notification = notification.first()
-            raw_notification = getattr(first_notification, "raw_notification", None) if first_notification else None
-            provider = getattr(raw_notification, "provider", None) if raw_notification else None
-            if provider:
-                notification_provider = provider
-
-        data["notification_provider"] = notification_provider
-        return data
-
-
 class CircuitMaintenanceUIViewSet(NautobotUIViewSet):
     """UIViewSet for CircuitMaintenance."""
 
@@ -243,7 +223,7 @@ class CircuitMaintenanceUIViewSet(NautobotUIViewSet):
 
     object_detail_content = ObjectDetailContent(
         panels=(
-            CustomMaintenanceFieldsPanel(
+            ObjectFieldsPanel(
                 weight=100,
                 section=SectionChoices.LEFT_HALF,
                 fields="__all__",
@@ -406,9 +386,6 @@ class RawNotificationUIViewSet(
             ),
         )
     )
-    serializer_class = serializers.RawNotificationSerializer
-    table_class = tables.RawNotificationTable
-    action_buttons = ("export",)
 
     def get_extra_context(self, request, instance=None):
         """Extend content of detailed view for RawNotification."""
@@ -444,18 +421,24 @@ class NotificationObjectFieldsPanel(ObjectFieldsPanel):
     def get_data(self, context):
         """Render providers as a list of hyperlinks."""
         instance = context.get("object") or context.get(self.context_object_key)
+        # `account`, `source_type`, and `providers_display` are not model fields; they are attached to the
+        # instance here so the panel can surface source metadata that only exists at runtime via Source.init().
         try:
             source = Source.init(name=instance.name)
             setattr(instance, "account", source.get_account_id())
             setattr(instance, "source_type", source.__class__.__name__)
-        except (AttributeError, TypeError, ValueError):
+        except ValueError as exc:
+            logger.warning(
+                "Failed to initialize notification source %s: %s",
+                instance.name,
+                exc,
+                exc_info=True,
+                extra={"object": instance},
+            )
             setattr(instance, "account", None)
             setattr(instance, "source_type", None)
 
-        try:
-            setattr(instance, "providers_display", instance.providers.all())
-        except (AttributeError, TypeError):
-            setattr(instance, "providers_display", [])
+        setattr(instance, "providers_display", instance.providers.all())
 
         if not hasattr(instance, "authentication_message"):
             setattr(instance, "authentication_message", None)
@@ -525,32 +508,38 @@ class NotificationSourceUIViewSet(NautobotUIViewSet):
         custom_view_additional_permissions=["nautobot_circuit_maintenance.view_notificationsource"],
     )
     def validate_source(self, request, pk=None):  # pylint: disable=unused-argument
-        """Validate NotificationSource authentication and render result directly for tests."""
+        """Validate NotificationSource authentication and redirect back to the detail view with the result."""
         instance = self.get_object()
-        source = None
         try:
             source = Source.init(name=instance.name)
             is_authenticated, mess_auth = source.test_authentication()
-            message = "SUCCESS: " + mess_auth if is_authenticated else "FAILED: " + mess_auth
-        except (AttributeError, TypeError, ValueError) as exc:
+            message = f"SUCCESS: {mess_auth}" if is_authenticated else f"FAILED: {mess_auth}"
+        except RedirectAuthorize as exc:
+            # OAuth sources (e.g. Gmail) raise this to send the user through the provider consent flow.
+            try:
+                return redirect(
+                    reverse(
+                        f"plugins:nautobot_circuit_maintenance:{exc.url_name}",
+                        kwargs={"name": exc.source_name},
+                    )
+                )
+            except NoReverseMatch:
+                message = "FAILED: Redirect required but target URL could not be resolved."
+        except ValueError as exc:
+            logger.warning(
+                "Failed to validate authentication for notification source %s: %s",
+                instance.name,
+                exc,
+                exc_info=True,
+                extra={"object": instance},
+            )
             message = f"FAILED: {exc}"
 
-        context = {
-            "object": instance,
-            "authentication_message": message,
-            "providers": instance.providers.all(),
-            "account": source.get_account_id() if source else None,
-            "source_type": source.__class__.__name__ if source else None,
-            "active_tab": "main",
-        }
-        context["verbose_name"] = (
-            instance._meta.verbose_name.title() if hasattr(instance._meta, "verbose_name") else "Notification Source"
-        )
-        context["associated_contacts_table"] = ContactAssociationTable([])
-        context["associated_dynamic_groups_table"] = DynamicGroupTable([])
-        context["associated_object_metadata_table"] = ObjectMetadataTable([])
-
-        return render(request, "nautobot_circuit_maintenance/notificationsource.html", context)
+        if message.startswith("SUCCESS"):
+            messages.success(request, message)
+        else:
+            messages.error(request, message)
+        return redirect(instance.get_absolute_url())
 
 
 def google_authorize(request, name):


### PR DESCRIPTION
## What this is

Follow-up review fixes on top of the merged #350 UI Component Framework refactor, targeting the `u/pavan-uicomponents-easy-kc` integration branch (not `develop`). #350 moved the detail views to the declarative framework and dropped the custom `*_retrieve.html` templates — good direction. This PR addresses one functional regression plus several cleanups our review flagged, and adds regression test coverage.

All changes are in `nautobot_circuit_maintenance/views.py` and `nautobot_circuit_maintenance/tests/test_views.py`.

## Changes

### 1. Fix: `validate_source` no longer 500s on OAuth sources (the one blocker)
`Source.test_authentication()` deliberately re-raises `RedirectAuthorize` (`sources.py`) for OAuth sources (e.g. Gmail) that need to send the user through the provider consent flow. After the refactor, `validate_source` only caught `(AttributeError, TypeError, ValueError)`, so `RedirectAuthorize` escaped as an unhandled 500 — and the "Validate Authentication" button links straight to this action, so it was user-reachable.

`validate_source` now:
- Catches `RedirectAuthorize` and redirects to the OAuth authorize URL (restores pre-refactor behavior).
- Catches `ValueError` and **logs it** with `exc_info=True` (the refactor had dropped the logging).
- Attaches a Django `messages` flash (success/error) and **redirects back to the object detail view**, instead of `render()`-ing the legacy `notificationsource.html` template with three hand-built empty tables.

Why redirect-with-messages instead of the direct `render()`:
- It's the idiomatic pattern for a POST/GET action that reports a result, and it lets the detail page render via the UI framework rather than the legacy backward-compat template.
- It removes the "Temporary fix to pass test cases" scaffolding (the empty `ContactAssociationTable([])` / `DynamicGroupTable([])` / `ObjectMetadataTable([])`).
- Note: the previous implementation also supported a `return_url` GET param and redirected to it directly. I intentionally did **not** restore that — redirecting to a user-supplied URL is an open-redirect risk. We always redirect to the object's own detail page.

### 2. Cleanup: remove dead `CustomMaintenanceFieldsPanel`
This panel only existed to compute `data["notification_provider"]`, which is written but never read anywhere (no template or field references it). Replaced its single usage with a plain `ObjectFieldsPanel(fields="__all__")` and removed the now-unused `get_obj_from_context` import. No behavior change.

### 3. Cleanup: remove duplicated class attributes in `RawNotificationUIViewSet`
`serializer_class`, `table_class`, and `action_buttons` were each declared twice (once above `object_detail_content`, once below). Removed the redundant second block.

### 4. Cleanup + logging: `NotificationObjectFieldsPanel.get_data`
- Narrowed `except (AttributeError, TypeError, ValueError)` to `except ValueError` (what `Source.init()` actually raises) so unrelated bugs aren't masked, and added a `logger.warning(..., exc_info=True)` on the failure path.
- Dropped the defensive `try/except` around `instance.providers.all()` (a plain reverse manager access that doesn't raise those exceptions).
- Added a comment explaining that `account` / `source_type` / `providers_display` are runtime-only pseudo-fields attached to the instance for display.

### 5. Tests
- Updated `test_validate_view_ok` / `test_validate_view_ko` to assert the new redirect-and-flash behavior (302 to the detail view + the message in the messages framework) instead of a 200 render.
- Added `test_validate_view_redirect_authorize` — the regression test for the OAuth path: a source that raises `RedirectAuthorize` now redirects to `google_authorize` instead of erroring.
- Extracted the repeated permission-granting setup into a small `_grant_view_permission()` helper.

## Not included (flagging for discussion)
- No new changelog fragment: this all rolls up under the existing `changes/350.housekeeping` for the UIComponent effort, and the target is the integration branch, so a second fragment would just create a duplicate release-notes line.
- The legacy `notificationsource.html` template is now unused by the validate flow. I left it in place to keep this PR scoped to the regression + cleanups; we can remove it in the branch's eventual develop merge (it already carries a "3.0 TODO: remove" comment).

## Test evidence
- `invoke unittest --label nautobot_circuit_maintenance.tests.test_views` → `Ran 179 tests ... OK (skipped=29)`.
- `NotificationSourceTest` (verbose) → `Ran 24 tests ... OK (skipped=4)`, including `test_validate_view_ok`, `test_validate_view_ko`, and the new `test_validate_view_redirect_authorize`.
- `ruff check` / `ruff format --check` clean on both changed files.
